### PR TITLE
🧹 Code Health: Remove commented-out debugging print statements

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -269,12 +269,6 @@ plot_data %>%
   dplyr::arrange(desc(n)) %>%
   knitr::kable()
 
-# 2. Inspect your data (optional, but highly recommended for debugging)
-# print(str(plot_data))
-# print(summary(plot_data$size))
-# print(sum(is.na(plot_data$size)))
-# print(range(plot_data$size, na.rm = TRUE))
-
 # 1. Define your colors in a named vector
 # You must assign a color to every category, or the others will disappear/turn grey.
 my_colors <- c(


### PR DESCRIPTION
🎯 **What:** Removed commented-out debugging print statements from `adhd_adults_diagnosis.qmd`.
💡 **Why:** These statements were left over from development. Removing them improves the overall readability and maintainability of the codebase by eliminating unnecessary clutter.
✅ **Verification:** A Python verification script was run to ensure that only the targeted lines were removed and no surrounding code or functionality was altered. The script was then deleted to keep the workspace clean.
✨ **Result:** A cleaner, more readable R Markdown file without residual debug code.

---
*PR created automatically by Jules for task [8566878124273933368](https://jules.google.com/task/8566878124273933368) started by @jeremymiles*