### PR TITLE
🧹 Remove dead code breaking quarto in contMA.R

### DIFF
--- a/contMA.R
+++ b/contMA.R
@@ -212,8 +212,6 @@ ContMA <- function(
       
       cat("<h6>Trim and Fill</h6>")
       
-      # Line below breaks quarto
-      #metafor::trimfill(fit_ma) %>% print()
       cat("Estimate and Cis<p>")
       coef(summary(trimfill(fit_ma))) %>%
         as.data.frame() %>%


### PR DESCRIPTION
🎯 **What:** Removed commented-out `metafor::trimfill(fit_ma) %>% print()` and its accompanying explanatory comment in `contMA.R`.
💡 **Why:** As noted in the source file, this line breaks quarto. It is dead code that is already commented out and can be removed entirely to improve code maintainability and cleanliness.
✅ **Verification:** Verified that the lines were successfully removed from `contMA.R` using grep.
✨ **Result:** Cleaned up dead code from the project.

---
*PR created automatically by Jules for task [12849088281974937444](https://jules.google.com/task/12849088281974937444) started by @jeremymiles*