### PR TITLE
🧹 [Code Health] Remove commented out install.packages

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -587,7 +587,6 @@ calculate_adhd_stats <- function(data) {
 }
 accuracy <- calculate_adhd_stats(accuracy)
 head(accuracy)
-#install.packages("kableExtra")
 
 
 accuracy <- accuracy %>%


### PR DESCRIPTION
🎯 **What:** Removed the commented out `#install.packages("kableExtra")` from `adhd_adults_diagnosis.qmd`.

💡 **Why:** Package installation commands should not be left in analysis scripts, even as comments. This improves code cleanliness, as package management should generally be handled at the environment or setup level.

✅ **Verification:**
- Validated via shell commands (`cat` and `sed`) that the correct line was removed cleanly.
- Verified that removing commented code cannot alter the program's runtime behavior.
- Requested and passed code review.

✨ **Result:** A slightly cleaner analysis script with dead code removed.

---
*PR created automatically by Jules for task [6354422202407001748](https://jules.google.com/task/6354422202407001748) started by @jeremymiles*