### PR TITLE
🧹 Remove commented-out metafor::trimfill print statement

### DIFF
--- a/CatMA.R
+++ b/CatMA.R
@@ -189,8 +189,6 @@ CatMA <- function(
       
       cat("<h6>Trim and Fill</h6>")
       
-      # Line below breaks quarto
-      #metafor::trimfill(fit_ma) %>% print()
       cat("Estimate and Cis<p>")
       coef(summary(trimfill(fit_ma))) %>%
         as.data.frame() %>%


### PR DESCRIPTION
🎯 **What:** Removed commented-out `metafor::trimfill(fit_ma) %>% print()` statement and its preceding comment in `CatMA.R`.
💡 **Why:** The comment explicitly stated "Line below breaks quarto", indicating this code was intentionally disabled. Removing it cleans up the file, reducing clutter and improving maintainability.
✅ **Verification:** Verified the removal using `cat` and `grep` commands to ensure the correct lines were deleted without affecting surrounding code. Additionally, verified no unmatched curly braces were introduced via a custom python script.
✨ **Result:** A cleaner `CatMA.R` file free of dead, disabled code that caused known issues with Quarto.

---
*PR created automatically by Jules for task [7377325234560295919](https://jules.google.com/task/7377325234560295919) started by @jeremymiles*