### PR TITLE
🎨 Palette: Improve chart accessibility with colorblind-friendly palette

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - High-Contrast Colorblind-Safe Data Visualizations
+**Learning:** Hardcoded, low-contrast colors (like "yellow") in scatter plots and charts are not accessible, fail WCAG contrast guidelines on white backgrounds, and are generally difficult to read. Furthermore, standard named colors (red, blue, green) are often indistinguishable to colorblind users.
+**Action:** Use colorblind-friendly color palettes, such as the Okabe-Ito palette, for data visualizations to ensure accessibility and readability for all users.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -280,12 +280,13 @@ plot_data %>%
 
 # 1. Define your colors in a named vector
 # You must assign a color to every category, or the others will disappear/turn grey.
+# Using Okabe-Ito colorblind-friendly palette
 my_colors <- c(
-  "ASRS"  = "red",    # Replace with your preferred color
-  "CAARS" = "blue",   # Replace with your preferred color
-  "BAARS" = "darkgreen",  # Replace with your preferred color
-  "WURS" = "brown4",  # Replace with your preferred color
-  "Other" = "black"   # The specific requirement
+  "ASRS"  = "#E69F00",  # Orange
+  "CAARS" = "#56B4E9",  # Sky blue
+  "BAARS" = "#009E73",  # Bluish green
+  "WURS"  = "#CC79A7",  # Reddish purple
+  "Other" = "#000000"   # Black
 )
 
 # 2. Plot
@@ -367,13 +368,14 @@ plot_data <- plot_data %>%
       ifelse(substr(test_description, 1, 5) == "Go-No", "Go-NoGo", `Frequent Tools`)
   )
 
+# Using Okabe-Ito colorblind-friendly palette
 my_colors <- c(
-  "AQT"  = "red",    # Replace with your preferred color
-  "C-CPT" = "blue",   # Replace with your preferred color
-  "MOXO" = "darkgreen",  # Replace with your preferred color
-  "QbTest" = "chocolate4",
-  "Go-NoGo" = "yellow",
-  "Other" = "black"   # The specific requirement
+  "AQT"     = "#E69F00", # Orange
+  "C-CPT"   = "#56B4E9", # Sky blue
+  "MOXO"    = "#009E73", # Bluish green
+  "QbTest"  = "#0072B2", # Blue
+  "Go-NoGo" = "#D55E00", # Vermilion (replaces low-contrast yellow)
+  "Other"   = "#000000"  # Black
 )
 
 plot_data %>% ggplot2::ggplot(


### PR DESCRIPTION
💡 **What:** Replaced hardcoded, non-accessible colors (such as low-contrast "yellow" and indistinguishable "red" / "green" pairings) in the data visualizations within `adhd_adults_diagnosis.qmd` with hex codes from the widely-used, colorblind-friendly Okabe-Ito palette.

🎯 **Why:** To ensure that all generated charts and scatter plots are legible and visually distinct for all users, including those with color vision deficiencies. Standard named colors often fail WCAG contrast guidelines on white backgrounds or are difficult to differentiate.

♿ **Accessibility:** Significantly improves color contrast and colorblind safety for data visualizations, making the presented research findings accessible to a wider audience.

---
*PR created automatically by Jules for task [123943265874439269](https://jules.google.com/task/123943265874439269) started by @jeremymiles*