### PR TITLE
🎨 Palette: Update to accessible colorblind-friendly palette in data visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Accessible Color Palettes for Data Visualization]
+**Learning:** Using basic hardcoded colors (like 'red', 'yellow', 'green') in data visualizations creates accessibility barriers for users with color vision deficiencies, reducing contrast and legibility.
+**Action:** When creating data visualizations, consistently apply an accessible, colorblind-friendly palette (such as Okabe-Ito) to ensure all users can accurately interpret the data.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -282,11 +282,11 @@ plot_data %>%
 # 1. Define your colors in a named vector
 # You must assign a color to every category, or the others will disappear/turn grey.
 my_colors <- c(
-  "ASRS"  = "red",    # Replace with your preferred color
-  "CAARS" = "blue",   # Replace with your preferred color
-  "BAARS" = "darkgreen",  # Replace with your preferred color
-  "WURS" = "brown4",  # Replace with your preferred color
-  "Other" = "black"   # The specific requirement
+  "ASRS"  = "#E69F00",    # Replace with your preferred color
+  "CAARS" = "#56B4E9",   # Replace with your preferred color
+  "BAARS" = "#009E73",  # Replace with your preferred color
+  "WURS" = "#F0E442",  # Replace with your preferred color
+  "Other" = "#000000"   # The specific requirement
 )
 
 # 2. Plot
@@ -369,12 +369,12 @@ plot_data <- plot_data %>%
   )
 
 my_colors <- c(
-  "AQT"  = "red",    # Replace with your preferred color
-  "C-CPT" = "blue",   # Replace with your preferred color
-  "MOXO" = "darkgreen",  # Replace with your preferred color
-  "QbTest" = "chocolate4",
-  "Go-NoGo" = "yellow",
-  "Other" = "black"   # The specific requirement
+  "AQT"  = "#E69F00",    # Replace with your preferred color
+  "C-CPT" = "#56B4E9",   # Replace with your preferred color
+  "MOXO" = "#009E73",  # Replace with your preferred color
+  "QbTest" = "#D55E00",
+  "Go-NoGo" = "#F0E442",
+  "Other" = "#000000"   # The specific requirement
 )
 
 plot_data %>% ggplot2::ggplot(


### PR DESCRIPTION
💡 **What:** 
Replaced hardcoded basic colors in the data visualization generation script (`adhd_adults_diagnosis.qmd`) with the Okabe-Ito colorblind-friendly palette. Added an entry to `.Jules/palette.md` to record the rationale.

🎯 **Why:** 
Hardcoded generic colors (like red, green, and yellow) create accessibility barriers for users with color vision deficiencies, reducing contrast and legibility.

♿ **Accessibility:** 
The Okabe-Ito palette ensures that distinct categories are distinguishable by almost all individuals regardless of color vision.

---
*PR created automatically by Jules for task [3076037769122554469](https://jules.google.com/task/3076037769122554469) started by @jeremymiles*