### PR TITLE
🎨 Palette: Use accessible color palettes for data visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Use accessible color palettes for data visualizations
+**Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
+**Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -282,11 +282,11 @@ plot_data %>%
 # 1. Define your colors in a named vector
 # You must assign a color to every category, or the others will disappear/turn grey.
 my_colors <- c(
-  "ASRS"  = "red",    # Replace with your preferred color
-  "CAARS" = "blue",   # Replace with your preferred color
-  "BAARS" = "darkgreen",  # Replace with your preferred color
-  "WURS" = "brown4",  # Replace with your preferred color
-  "Other" = "black"   # The specific requirement
+  "ASRS"  = "#D55E00",    # Replace with your preferred color
+  "CAARS" = "#0072B2",   # Replace with your preferred color
+  "BAARS" = "#009E73",  # Replace with your preferred color
+  "WURS"  = "#CC79A7",  # Replace with your preferred color
+  "Other" = "#000000"   # The specific requirement
 )
 
 # 2. Plot
@@ -370,12 +370,12 @@ plot_data <- plot_data %>%
   )
 
 my_colors <- c(
-  "AQT"  = "red",    # Replace with your preferred color
-  "C-CPT" = "blue",   # Replace with your preferred color
-  "MOXO" = "darkgreen",  # Replace with your preferred color
-  "QbTest" = "chocolate4",
-  "Go-NoGo" = "yellow",
-  "Other" = "black"   # The specific requirement
+  "AQT"     = "#D55E00",    # Replace with your preferred color
+  "C-CPT"   = "#0072B2",   # Replace with your preferred color
+  "MOXO"    = "#009E73",  # Replace with your preferred color
+  "QbTest"  = "#CC79A7",
+  "Go-NoGo" = "#E69F00",
+  "Other"   = "#000000"   # The specific requirement
 )
 
 plot_data %>% ggplot2::ggplot(


### PR DESCRIPTION
**💡 What:** Replaced hardcoded basic colors (e.g., "red", "green", "yellow", "chocolate4") in `adhd_adults_diagnosis.qmd` data visualizations with accessible, colorblind-friendly hex codes from the Okabe-Ito palette (e.g., `#D55E00`, `#009E73`, `#E69F00`, `#CC79A7`). Also added a journal entry in `.Jules/palette.md` documenting this finding.
**🎯 Why:** Basic hardcoded colors can be extremely difficult to distinguish for users with color vision deficiencies (like deuteranopia or protanopia), making charts hard to interpret. Using Okabe-Ito colors ensures the visualizations are accessible to a wider audience.
**📸 Before/After:** (N/A visual change in Quarto output, code change only applied to `my_colors` definitions).
**♿ Accessibility:** Greatly improves color contrast and distinguishability for users with color vision deficiencies reading the resulting plots.

---
*PR created automatically by Jules for task [11999084042326581098](https://jules.google.com/task/11999084042326581098) started by @jeremymiles*