### PR TITLE
🎨 Palette: Improve accessibility of data visualizations with Okabe-Ito colors

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -980,7 +980,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -1008,7 +1008,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     


### PR DESCRIPTION
💡 What: Replaced hardcoded 'red' color used in meta-analysis forest plots with a more accessible color ('#D55E00', Okabe-Ito palette) in `adhd_adults_diagnosis.qmd`.
🎯 Why: Hardcoded basic colors (like 'red') can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility of the data visualizations. The Okabe-Ito palette is specifically designed to be accessible to a wider audience.
📸 Before/After: Visual update on the Sensitivity and Specificity sections of the meta-analysis plot.
♿ Accessibility: Ensures that data visualizations are easily distinguishable for users with colorblindness.

---
*PR created automatically by Jules for task [6308318093601185063](https://jules.google.com/task/6308318093601185063) started by @jeremymiles*