### PR TITLE
🎨 Palette: Improve accessibility of meta-analysis visualization

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -1003,7 +1003,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -1031,7 +1031,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     


### PR DESCRIPTION
💡 What: Replaced the basic "red" color used for the summary polygons in the meta-analysis forest plots with "#D55E00" (Vermilion).
🎯 Why: The original red color is difficult for users with color vision deficiencies (such as protanopia or deuteranopia) to distinguish clearly. This small change enhances the accessibility of the diagnostic charts.
♿ Accessibility: Uses the Okabe-Ito color palette, which is specifically designed to be highly visible and easily distinguishable for all users, including those with colorblindness.

---
*PR created automatically by Jules for task [8346346974273661078](https://jules.google.com/task/8346346974273661078) started by @jeremymiles*