### PR TITLE
🎨 Palette: Improve accessibility of meta-analysis plots

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -1003,7 +1003,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -1031,7 +1031,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     


### PR DESCRIPTION
💡 What: Replaced hardcoded "red" strings in `addpoly` calls with `#D55E00` (Vermillion) from the colorblind-friendly Okabe-Ito palette.
🎯 Why: Hardcoded basic colors like "red" can be extremely difficult for users with color vision deficiencies to distinguish. Using a colorblind-friendly palette improves the accessibility and overall usability of the data visualizations.
♿ Accessibility: Improved color contrast and visibility for colorblind users by replacing inaccessible generic "red" with a color specifically formulated to be easily distinguishable.

---
*PR created automatically by Jules for task [10075445791539388652](https://jules.google.com/task/10075445791539388652) started by @jeremymiles*