### PR TITLE
🎨 Palette: Use accessible Okabe-Ito color palette in data visualizations

### DIFF
--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -520,6 +520,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
     aes(x = Group, y = value, color = measure)
   )  + 
   geom_boxplot() +
+  scale_color_manual(values = c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")) +
   facet_wrap(~ type) +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
 


### PR DESCRIPTION
💡 What: Added the Okabe-Ito accessible color palette (`scale_color_manual`) to the final `ggplot` chart in `adhd_adults_diagnosis.qmd`.
🎯 Why: Hardcoded default colors in ggplot can be difficult or impossible to distinguish for users with color vision deficiencies (CVD). 
📸 Before/After: Before, the plot used default unconstrained hues. Now, it uses the high-contrast Okabe-Ito palette.
♿ Accessibility: Improves visual accessibility for colorblind users by using a standard CVD-friendly color palette (Okabe-Ito).

---
*PR created automatically by Jules for task [7435867765477306179](https://jules.google.com/task/7435867765477306179) started by @jeremymiles*