### PR TITLE
🎨 Palette: Improve accessibility of colors in meta-analysis plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced hardcoded "red" colors with "#D55E00" (vermilion) in the `addpoly` function calls within `adhd_adult_meta_anlaysis.qmd`.

🎯 Why: Hardcoded basic colors like "red" can be difficult to distinguish for users with color vision deficiencies. Vermilion is part of the colorblind-friendly Okabe-Ito palette.

📸 Before/After: Visual update on the generated meta-analysis forest plots (summary polygon color changed from standard red to an accessible shade of vermilion).

♿ Accessibility: Ensures that key statistical visual cues in the summary plots are distinguishable for users with protanopia and deuteranopia, following best practices for data visualization.

---
*PR created automatically by Jules for task [4943371646864868820](https://jules.google.com/task/4943371646864868820) started by @jeremymiles*