### PR TITLE
🎨 Palette: Replace hardcoded red with accessible colorblind-friendly palette in meta-analysis plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What**: Replaced the hardcoded 'red' color used in the meta-analysis forest plots (specifically the summary polygons via `addpoly`) with `#D55E00`.
🎯 **Why**: Using hardcoded, basic colors like "red" makes data visualizations difficult to interpret for users with color vision deficiencies.
📸 **Before/After**: N/A
♿ **Accessibility**: Vermilion (`#D55E00`) is part of the Okabe-Ito color palette, which is specifically designed to be easily distinguishable by users with deuteranopia and protanopia, thus significantly improving the accessibility of the forest plots generated in this document.

---
*PR created automatically by Jules for task [13838428981529329979](https://jules.google.com/task/13838428981529329979) started by @jeremymiles*