### PR TITLE
🎨 Palette: Replace hardcoded basic colors with accessible palette

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced the hardcoded basic color (`"red"`) with the accessible, colorblind-friendly Okabe-Ito palette color (`"#D55E00"`) in the data visualizations within `adhd_adult_meta_anlaysis.qmd`.

🎯 Why: Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations can be extremely difficult to distinguish for users with color vision deficiencies. This reduces the usability and inclusivity of the charts.

📸 Before/After: Before, the `addpoly` function for the forest plots used `col = "red"`. After, it uses `col = "#D55E00"` (a vermilion shade from the Okabe-Ito palette).

♿ Accessibility: This change directly improves visualization accessibility for users with color vision deficiencies, ensuring everyone can properly distinguish and understand the highlighted data in the plots.

---
*PR created automatically by Jules for task [17356161789100884499](https://jules.google.com/task/17356161789100884499) started by @jeremymiles*