### PR TITLE
🎨 Palette: Improve accessibility of meta-analysis plots by using colorblind-friendly color

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Updated the `col` parameter in `addpoly()` calls within `adhd_adult_meta_anlaysis.qmd` from "red" to "#D55E00".
🎯 Why: Hardcoded basic colors like "red" can be difficult to distinguish for users with color vision deficiencies. Using a colorblind-friendly vermillion from the Okabe-Ito palette improves the inclusiveness and accessibility of the data visualizations.
📸 Before/After: Before, the added polygon in the forest plot was "red". After, it is a distinctly identifiable colorblind-friendly vermillion ("#D55E00").
♿ Accessibility: Directly improves the accessibility of the generated meta-analysis plots by employing a color palette that is safe for individuals with colorblindness.

---
*PR created automatically by Jules for task [16432234383091375496](https://jules.google.com/task/16432234383091375496) started by @jeremymiles*