### PR TITLE
🎨 Palette: Improve forest plot accessibility with colorblind-friendly palette

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Accessible polygon colors in Metafor forest plots
+**Learning:** Hardcoded basic colors like "red" for the summary polygons (`addpoly`) in `metafor` forest plots can cause issues for colorblind users and fail accessibility contrast checks.
+**Action:** Use an accessible colorblind-friendly hex code (e.g., `#D55E00` for Okabe-Ito vermilion) instead of basic strings when highlighting summary effects in R plot methods like `addpoly`.

--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced hardcoded `"red"` colors in the summary polygons (`addpoly`) of `metafor` forest plots with an Okabe-Ito vermilion hex code (`#D55E00`).
🎯 Why: Hardcoded basic colors like "red" can be indistinguishable for users with color vision deficiencies. Using a colorblind-friendly palette ensures that all users can clearly identify the summary effects in these plots.
📸 Before/After: Visual plots now use a highly accessible vermilion color instead of basic red.
♿ Accessibility: Improved contrast and discernibility for users with red-green colorblindness. Recorded this learning in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [10630545725019434869](https://jules.google.com/task/10630545725019434869) started by @jeremymiles*