### PR TITLE
🎨 Palette: Improve color accessibility in forest plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What**: Replaced the hardcoded 'red' color used in the metafor forest plots within `adhd_adult_meta_anlaysis.qmd` with `#D55E00` (Vermilion) from the Okabe-Ito palette.
🎯 **Why**: Hardcoded basic colors like "red" can be extremely difficult to distinguish for users with color vision deficiencies.
📸 **Before/After**: The summary polygon for the meta-analysis results in the forest plots now uses a highly distinguishable vermilion instead of a harsh, less accessible red.
♿ **Accessibility**: Significantly improves the visual distinguishability of the summary metric in data visualizations for users with color vision deficiencies, adhering to our established `.Jules/palette.md` guidelines for colorblind-friendly data plotting.

---
*PR created automatically by Jules for task [12814938655032503456](https://jules.google.com/task/12814938655032503456) started by @jeremymiles*