### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility of forest plots with colorblind-friendly palette

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-14 - Use accessible color palettes for data visualizations
-**Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
-**Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2026-03-17 - [Use Accessible Colors for Plots]
+**Learning:** Hardcoded base colors like 'red' in plots (e.g., metafor forest plots) can be inaccessible or difficult to read for colorblind users. The Okabe-Ito palette provides a robust set of colors that are distinguishable by all types of color vision.
+**Action:** Replace basic color assignments like `col = "red"` with an accessible equivalent, such as the Okabe-Ito vermilion (`col = "#D55E00"`), across data visualizations to ensure accessibility.

--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What**: Changed the hardcoded "red" color in `adhd_adult_meta_anlaysis.qmd` meta-analysis forest plots to `#D55E00`, an accessible vermilion from the Okabe-Ito palette.

🎯 **Why**: Standard base colors like "red" can be indistinguishable for users with various forms of color blindness (such as deuteranomaly or protanomaly). Using the Okabe-Ito color palette ensures that these important visual markers are accessible and legible for everyone.

📸 **Before/After**: 
**Before**: `col = "red"`
**After**: `col = "#D55E00"`

♿ **Accessibility**: Considerably improves accessibility for users with color vision deficiencies, ensuring the critical information highlighted in these plots is perceivable by all users.

---
*PR created automatically by Jules for task [6205017191573031229](https://jules.google.com/task/6205017191573031229) started by @jeremymiles*