### PR TITLE
🎨 Palette: Replace hardcoded red with accessible vermilion in plot

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced the hardcoded "red" color in `metafor::addpoly` function calls with `#D55E00` (vermilion) in `adhd_adult_meta_anlaysis.qmd`.

🎯 Why: To improve the accessibility of the diagnostic meta-analysis plots. Hardcoded basic colors like "red" can be difficult to distinguish for users with color vision deficiencies. Vermilion is part of the colorblind-friendly Okabe-Ito palette.

📸 Before/After: Visual update to metafor forest plot outcome summaries (no screenshot available, backend QMD generation).

♿ Accessibility: Ensures that summary polygons in meta-analysis forest plots are clearly distinguishable for users with color vision deficiencies, following the guidelines set in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1866899923019242890](https://jules.google.com/task/1866899923019242890) started by @jeremymiles*