### PR TITLE
🎨 Palette: Use Okabe-Ito color for forest plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+
+## 2024-10-24 - Avoid default basic colors in Metafor forest plots
+**Learning:** Hardcoded colors like `red` in forest plot functions (e.g., `metafor::addpoly`) can create contrast and accessibility issues for visually impaired users compared to colorblind-friendly alternatives.
+**Action:** Ensure custom polygons and highlights in forest plots use accessible colors like the Okabe-Ito palette (e.g., `#D55E00` instead of `red`).

--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What:** 
Replaced hardcoded `col = "red"` with the Okabe-Ito colorblind-friendly `col = "#D55E00"` for the `addpoly` function used in `metafor::forest` plots within `adhd_adult_meta_anlaysis.qmd`. Also recorded this accessibility insight in `.Jules/palette.md`.

🎯 **Why:** 
Hardcoded basic colors like pure "red" can be problematic for users with certain types of color vision deficiencies (e.g., protanopia). Replacing them with an accessible, colorblind-friendly palette such as Okabe-Ito improves the clarity and accessibility of the data visualizations.

📸 **Before/After:**
*Before:* `addpoly(..., col = "red", ...)`
*After:* `addpoly(..., col = "#D55E00", ...)`

♿ **Accessibility:**
Provides a distinct vermillion color (`#D55E00`) that offers much better contrast and distinguishability for visually impaired users compared to standard "red".

---
*PR created automatically by Jules for task [17881376456327364593](https://jules.google.com/task/17881376456327364593) started by @jeremymiles*