### PR TITLE
🎨 Palette: Improve accessibility of forest plot polygons

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What**: Replaced hardcoded `red` color values with the Okabe-Ito vermilion (`#D55E00`) in the meta-analysis forest plots inside `adhd_adult_meta_anlaysis.qmd`.

🎯 **Why**: Hardcoded basic colors (like pure red) can be difficult to distinguish for users with color vision deficiencies, reducing the accessibility of data visualizations.

📸 **Before/After**: The polygon elements representing Sensitivity and Specificity will now render in a universally accessible vermilion color instead of standard pure red.

♿ **Accessibility**: This change directly addresses visual accessibility by aligning data visualization elements with colorblind-friendly design principles.

---
*PR created automatically by Jules for task [15431937109603855234](https://jules.google.com/task/15431937109603855234) started by @jeremymiles*