### PR TITLE
🎨 Palette: Improve accessibility of meta-analysis plots by using colorblind-friendly color

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
**💡 What:** Replaced the hardcoded basic color `"red"` with the colorblind-friendly hex code `"#D55E00"` (vermilion from the Okabe-Ito palette) for summary polygon highlights in the meta-analysis forest plots.
**🎯 Why:** Users with color vision deficiencies, particularly deuteranopia and protanopia, can find it extremely difficult to distinguish pure reds from greens, browns, and dark greys. Hardcoding basic colors in data visualizations creates an inaccessible experience for these users.
**📸 Before/After:** Before: the pooled estimate diamonds in the meta-analysis forest plots were pure red. After: they are a distinct vermilion, a color empirically designed and tested to be easily distinguishable by users with common types of color blindness.
**♿ Accessibility:** This change improves compliance with WCAG success criteria related to use of color, directly aiding users with color vision deficiencies. No new UI dependencies or CSS files were added, nor were any logic changes introduced.

---
*PR created automatically by Jules for task [16900179554063381011](https://jules.google.com/task/16900179554063381011) started by @jeremymiles*