### PR TITLE
🎨 Palette: Use accessible color in meta-analysis forest plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced the hardcoded "red" color in the `addpoly` function for forest plots in `adhd_adult_meta_anlaysis.qmd` with the hex color `#D55E00`.
🎯 Why: Standard basic colors like "red" can be extremely difficult to distinguish for users with color vision deficiencies (like protanopia and deuteranopia), reducing the accessibility of data visualizations.
📸 Before/After: Before, forest plot summary polygons were displayed in standard red. Now they are displayed in `#D55E00` (Vermilion).
♿ Accessibility: Uses Vermilion (`#D55E00`), which is part of the universally recommended Okabe-Ito colorblind-friendly palette. This guarantees that the visualizations are accessible to users with various forms of colorblindness.

---
*PR created automatically by Jules for task [12934931149228335144](https://jules.google.com/task/12934931149228335144) started by @jeremymiles*