### PR TITLE
🎨 Palette: [Add alternative text to all ggplot visualizations]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Add alternative text to ggplot2 visualizations
+**Learning:** In Quarto/RMarkdown documents, `ggplot2` plots generated within loops or independently often lack alternative text, making the visual data inaccessible to screen readers. Relying on default behavior or static descriptions for dynamic plots is insufficient.
+**Action:** Always add `labs(alt = '...')` directly within `ggplot2::ggplot()` calls to provide alternative text. When generating plots in a loop, dynamically construct the `alt` text using functions like `paste()` to ensure the description accurately reflects the specific iteration's data.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -143,6 +143,7 @@ ggplot2::ggplot(
   aes(
     x = sensitivity, 
     y = specificity)) +
+  labs(alt = "Scatter plot of sensitivity versus specificity for diagnostic tools") +
   geom_point() +
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
@@ -162,6 +163,7 @@ ggplot2::ggplot(
     x = sensitivity, 
     y = specificity,
     colour = name, shape = Neurotypical)) +
+  labs(alt = "Scatter plot of sensitivity versus specificity for diagnostic tools, faceted by tool type and colored by name") +
   geom_point(size = 2.5) +
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
@@ -187,7 +189,8 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot of sensitivity versus specificity for diagnostic tools, faceted by tool type showing neurotypical only shapes"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot of sensitivity versus specificity for Self-Report Questionnaires, sized by study size and colored by frequent tools"
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot of sensitivity versus specificity for Neuropsychological Tests, sized by study size and colored by frequent tools"
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -498,6 +504,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   ggplot2::ggplot(
     aes(x = Group, y = value)
   )  + 
+  labs(alt = "Boxplot of accuracy and AUC values across different diagnostic tools by group") +
   geom_boxplot() +
   facet_grid(type ~ measure)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
@@ -508,6 +515,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   ggplot2::ggplot(
     aes(x = Group, y = value)
   )  + 
+  labs(alt = "Boxplot of accuracy and AUC values faceted by measure and type") +
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
@@ -519,6 +527,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   ggplot2::ggplot(
     aes(x = Group, y = value, color = measure)
   )  + 
+  labs(alt = "Boxplot of accuracy and AUC values by group, colored by measure and faceted by tool type") +
   geom_boxplot() +
   facet_wrap(~ type) +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))


### PR DESCRIPTION
💡 **What:** Added descriptive alternative text (`alt` attributes) to all 9 `ggplot2::ggplot` invocations in `adhd_adults_diagnosis.qmd`. 
🎯 **Why:** To make the generated data visualizations accessible to users relying on screen readers, ensuring that they can understand the content and structure of the plots even if they cannot see them visually. 
📸 **Before/After:** No visual changes. This is a metadata update to the generated image outputs.
♿ **Accessibility:** Screen readers will now read out descriptions of the charts, including dynamic text tailored to the specific chart iteration for charts generated within loops. Added a critical learning to `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [16812411310757943906](https://jules.google.com/task/16812411310757943906) started by @jeremymiles*