### PR TITLE
🎨 Palette: Add dynamic alt text to looped ggplot2 charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-06-25 - Dynamic Alt Text
+**Learning:** Dynamic alternative text is crucial for accessibility in generated plot loops to avoid redundant screen reader descriptions.
+**Action:** Use `labs(alt = ...)` with dynamically generated strings (like `paste()`) in ggplot2 loops.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
🎯 What: Added dynamic alternative text to `ggplot2` scatter plots generated in a loop using `labs(alt = ...)` and `paste()`.

⚠️ Why: Screen readers need context to understand dynamically generated plots, especially when they are part of a loop and represent different subsets of data (in this case, sensitivity vs specificity for different diagnostic tools). Static descriptions would have been redundant and unhelpful.

📸 Before/After: Before, the plots lacked an `alt` tag, making them inaccessible. After, each plot gets a descriptive title like "Scatter plot of Sensitivity vs Specificity for [Tool Name]".

♿ Accessibility: This improves accessibility for visually impaired users relying on screen readers.

---
*PR created automatically by Jules for task [9886940886270338232](https://jules.google.com/task/9886940886270338232) started by @jeremymiles*