### PR TITLE
🎨 Palette: [UX improvement] Add dynamic alt text to ggplot charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-11-20 - Adding Dynamic Alt Text inside ggplot Loops
+**Learning:** Screen readers and accessibility tools require distinct alternative text for dynamically generated plots, especially when looping over multiple variables or categories to create similar charts. A static description is insufficient and can be confusing.
+**Action:** When creating plots within loops (e.g., using `ggplot2`), dynamically generate the `alt` text in the `labs(alt = ...)` function by interpolating the loop's iteration variable (e.g., using `paste()` or `glue()`) to ensure each plot's context is uniquely described.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** Added dynamically generated `alt` text to the `ggplot2` chart rendered inside the `for (name_1 in d_ss_long$name)` loop in `adhd_adults_diagnosis.qmd`.

🎯 **Why:** Dynamically generated scatter plots in the document were lacking context-specific alternative text. This made the charts inaccessible to screen readers. Adding descriptive `alt` text uniquely describes the specific category of each chart.

📸 **Before/After:** No visual changes. 

♿ **Accessibility:** By adding `alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "studies")` to the `labs()` layer, screen readers will now articulate what each specific plot visualizes instead of encountering ambiguous image elements.

---
*PR created automatically by Jules for task [15973484877253577479](https://jules.google.com/task/15973484877253577479) started by @jeremymiles*