### PR TITLE
🎨 Palette: Add alt text to ggplot2 charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add alt text to ggplot2 charts
+**Learning:** Screen readers and other assistive technologies cannot interpret the contents of dynamically generated plots, such as those made with `ggplot2`, leaving visually impaired users without context.
+**Action:** When creating `ggplot2` plots in RMarkdown/Quarto, use `labs(alt = "descriptive text")` to add descriptive alternative text to generated plot images. Ensure the text accurately describes the plot's content and structure.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -146,6 +146,7 @@ ggplot2::ggplot(
   geom_point() +
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
+  labs(alt = "Scatter plot showing sensitivity vs specificity for various ADHD diagnostic tools.") +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
@@ -167,6 +168,7 @@ ggplot2::ggplot(
   ylab("Specificity (%)") +
   facet_wrap(~ name_with_count) +
   guides(colour = "none") +
+  labs(alt = "Faceted scatter plot of sensitivity vs specificity across different diagnostic tools, grouped by neurotypical status.") +
   theme(legend.position = "bottom") +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -187,7 +189,8 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Faceted scatter plot of sensitivity vs specificity across different diagnostic tools, specifically highlighting neurotypical only participants."
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "highlighting neurotypical only participants.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot of sensitivity vs specificity for self-report questionnaires, showing different tools and highlighting neurotypical only participants."
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot of sensitivity vs specificity for neuropsychological tests, colored by frequent tools and highlighting neurotypical only participants."
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -500,6 +506,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_grid(type ~ measure)+
+  labs(alt = "Boxplots showing distribution of accuracy and AUC values across different participant groups, faceted by test type and measure.") +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
 
 # Figure 7
@@ -511,7 +518,10 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
-  labs(y = NULL)
+  labs(
+    y = NULL,
+    alt = "Boxplots of accuracy and AUC values across participant groups, organized with measures on rows and test types on columns."
+  )
 
 
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -521,6 +531,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_wrap(~ type) +
+  labs(alt = "Colored boxplots comparing accuracy and AUC values across participant groups, faceted by test type.") +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
 
 


### PR DESCRIPTION
💡 **What**: Added descriptive `alt` text to all 9 dynamically generated `ggplot2` charts in `adhd_adults_diagnosis.qmd`. This was accomplished by appending the `labs(alt = "...")` function to each plot's pipeline.

🎯 **Why**: Screen readers and other assistive technologies cannot interpret the raw pixel data of dynamically generated data visualizations. Without alternative text, visually impaired users are completely deprived of the context and insights provided by these charts. 

📸 **Before/After**: Visually, the charts remain identical to sighted users. However, the underlying HTML generated by Quarto now includes `alt` attributes on the `<img>` tags for each plot.

♿ **Accessibility**: This change directly addresses a WCAG conformance failure by providing text alternatives for non-text content, ensuring the data visualizations are accessible to all users.

---
*PR created automatically by Jules for task [5125386581559659406](https://jules.google.com/task/5125386581559659406) started by @jeremymiles*