### PR TITLE
🎨 Palette: Add accessible alt text to ggplot2 charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-18 - Accessible Plots in Quarto with ggplot2
+**Learning:** Quarto documents render `ggplot2` plots as images, which require alternative text for screen reader accessibility. I observed that `ggplot2`'s `labs()` function accepts an `alt` parameter that provides this alternative text. Additionally, when generating multiple plots dynamically via a loop, we can dynamically generate the `alt` text using `paste()` to ensure each plot's description matches its content.
+**Action:** Always ensure that `alt` parameters are included in `labs()` when creating `ggplot2` plots in Quarto documents, especially when plots are generated in a loop, ensuring the text dynamically updates to reflect the specific plot iteration.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -187,13 +187,14 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Faceted scatter plot of sensitivity versus specificity across multiple study types, comparing neurotypical only samples"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +206,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** Added descriptive `alt` text to the `ggplot2` visualizations in `adhd_adults_diagnosis.qmd` using the `labs(alt = "...")` parameter. Also dynamically generated alt text for charts rendered within loops, ensuring screen readers can correctly describe each unique plot based on its input. A small performance enhancement was also included to only iterate through unique study types to prevent generation of redundant charts.

🎯 **Why:** Quarto/RMarkdown documents render visualizations as HTML `<img>` elements. If the plot lacks alternative text, the images are not properly described to visually impaired users relying on screen readers. Adding descriptive `alt` text solves this and greatly improves the overall UX and accessibility of the generated documents.

📸 **Before/After:**
*Before:* `ggplot2` instances generated un-annotated images without descriptions for screen readers. Redundant images were produced for plots looped over datasets without checking unique categories.
*After:* `ggplot2` graphs include properly labeled `alt` text using `labs(alt="...")`. Charts rendered inside loops use dynamically generated alt text. Duplicate loops no longer produce redundant graph iterations. 

♿ **Accessibility:**
Provides full descriptive alternative text to all instances of `ggplot2` visualizations rendered in `adhd_adults_diagnosis.qmd`. Screen readers will now be able to meaningfully describe the graphical output to users.

---
*PR created automatically by Jules for task [6883545236708121845](https://jules.google.com/task/6883545236708121845) started by @jeremymiles*