### PR TITLE
🎨 Palette: Improve accessibility of forest plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Improve accessibility of metafor forest plots
+**Learning:** Hardcoded basic colors like "red" for polygons in metafor library forest plots can reduce accessibility for users with color vision deficiencies.
+**Action:** Replace basic hardcoded colors with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#D55E00`) in `addpoly` calls for forest plots to ensure maximum accessibility and readability.

--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 What: Replaced hardcoded `"red"` color with `#D55E00` (vermilion from the Okabe-Ito colorblind-friendly palette) in the `metafor::addpoly` calls for forest plots in `adhd_adult_meta_anlaysis.qmd`. Added an entry to `.Jules/palette.md` to document this learning.

🎯 Why: Hardcoded basic colors like "red" can be very difficult for users with color vision deficiencies to see or distinguish. Using an accessible color palette improves the readability and usability of the generated data visualizations.

♿ Accessibility: Ensures that polygons added to forest plots (which often highlight the meta-analytic summary estimate) are visible and distinct for all users, regardless of color vision capabilities.

📸 Before/After: N/A - visual change to plot output, but the code now explicitly uses accessible hex codes.

---
*PR created automatically by Jules for task [12440041354144279298](https://jules.google.com/task/12440041354144279298) started by @jeremymiles*