### PR TITLE
🎨 Palette: Add alt text to ggplot2 charts for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add alt text to ggplot2 charts
+**Learning:** Screen readers cannot interpret data visualizations created with ggplot2 in Quarto documents unless explicitly provided with alternative text.
+**Action:** Use `labs(alt = "...")` inside `ggplot()` calls to add meaningful alternative text describing the plot's content and trends. For plots generated in loops, dynamically generate the alt text.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -147,7 +147,8 @@ ggplot2::ggplot(
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
   xlim(c(0, 100)) + 
-  ylim(c(0, 100))
+  ylim(c(0, 100)) +
+  labs(alt = "Scatter plot showing sensitivity vs specificity for all studies")
 
 
 d_ss_long <- d_ss_long %>%
@@ -169,7 +170,8 @@ ggplot2::ggplot(
   guides(colour = "none") +
   theme(legend.position = "bottom") +
   xlim(c(0, 100)) + 
-  ylim(c(0, 100))
+  ylim(c(0, 100)) +
+  labs(alt = "Faceted scatter plot of sensitivity vs specificity across different test names")
 ```
 
 ```{r}
@@ -187,13 +189,14 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Faceted scatter plot of sensitivity vs specificity showing neurotypical only comparisons across test names"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste0("Scatter plot of sensitivity vs specificity for ", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot showing sensitivity vs specificity colored by frequent tools"
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot showing sensitivity vs specificity for objective measures with labels"
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -500,7 +506,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_grid(type ~ measure)+
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Boxplots of standardized values grouped by group, faceted by type and measure")
 
 # Figure 7
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -511,7 +518,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
-  labs(y = NULL)
+  labs(y = NULL, alt = "Boxplots of standardized values grouped by group, faceted by measure and type")
 
 
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -521,7 +528,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_wrap(~ type) +
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Boxplots of standardized values colored by measure, faceted by type")
 
 
 ```


### PR DESCRIPTION
## 💡 What
Added alternative text descriptions to all `ggplot2` visualizations in `adhd_adults_diagnosis.qmd` using the `labs(alt = "...")` argument. Also fixed an issue in the `for` loop that generated the faceted charts where it wasn't using `unique()` for names, creating duplicated prints. A new learning entry was also appended to `.Jules/palette.md`.

## 🎯 Why
Screen readers cannot interpret standard output images generated by Quarto/R Markdown without explicit `alt` text. This change ensures visually impaired users get a meaningful textual description of the generated plots' intent and content, improving the accessibility of the overall generated HTML documentation.

## 📸 Before/After
*Before:* `ggplot2` charts did not specify `alt` text, leading screen readers to read generic or no descriptions for the plot images.
*After:* Every plot generated with `ggplot2` uses `labs(alt = "...")` to describe the chart's structural intent. For iterative plots, the alt text is dynamically customized (e.g., `alt = paste0("Scatter plot of sensitivity vs specificity for ", name_1)`).

## ♿ Accessibility
This directly targets a major accessibility requirement (WCAG 1.1.1 Non-text Content) by making data visualization accessible to assistive technologies.

---
*PR created automatically by Jules for task [16266657630636955255](https://jules.google.com/task/16266657630636955255) started by @jeremymiles*