### PR TITLE
🎨 Palette: Add screen-reader alt text to all ggplot2 visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2026-04-02 - Add alt text to ggplot2
+**Learning:** Screen readers cannot interpret ggplot2 images natively, making data visualizations inaccessible.
+**Action:** Use labs(alt = '...') to add descriptive alternative text to generated plot images.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -146,6 +146,7 @@ ggplot2::ggplot(
   geom_point() +
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
+  labs(alt = "Scatterplot of sensitivity vs specificity for all studies") +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
@@ -167,6 +168,7 @@ ggplot2::ggplot(
   ylab("Specificity (%)") +
   facet_wrap(~ name_with_count) +
   guides(colour = "none") +
+  labs(alt = "Faceted scatterplots of sensitivity vs specificity by test type with study counts") +
   theme(legend.position = "bottom") +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -187,7 +189,8 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Faceted scatterplots showing sensitivity vs specificity across test types, highlighting neurotypical only studies"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatterplot of sensitivity vs specificity for", name_1, "tests")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatterplot of sensitivity vs specificity for Self-Report Questionnaires by specific tool"
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatterplot of sensitivity vs specificity for Neuropsychological Tests by specific tool"
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -500,6 +506,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_grid(type ~ measure)+
+  labs(alt = "Boxplots of Accuracy and AUC values across different study groups and test types") +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
 
 # Figure 7
@@ -511,7 +518,10 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
-  labs(y = NULL)
+  labs(
+    y = NULL,
+    alt = "Boxplots comparing Accuracy and AUC distributions across study groups by test type"
+  )
 
 
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -521,6 +531,7 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_wrap(~ type) +
+  labs(alt = "Faceted boxplots of performance measures by test type and study group") +
   theme(axis.text.x = element_text(angle = 90, hjust = 1))
 
 


### PR DESCRIPTION
**💡 What:**
Added descriptive `alt` text to all 9 `ggplot2` data visualizations in `adhd_adults_diagnosis.qmd` using `labs(alt = "...")`. For the plot generated inside a loop, `paste()` was used to ensure the `alt` text dynamically updates to reflect the specific data subset being visualized. Appended this accessibility finding to `.Jules/palette.md`.

**🎯 Why:**
Screen readers cannot inherently interpret graphical output from tools like `ggplot2`. Without explicit `alt` text, visually impaired users are completely excluded from understanding the data visualizations in the rendered Quarto HTML document.

**📸 Before/After:**
*Before:* `ggplot2` plots lacked the `alt` argument in `labs()`, meaning the rendered HTML `<img>` elements had no description.
*After:* All `ggplot2` plots now contain descriptive `alt` arguments, making the final HTML document fully accessible to screen readers.

**♿ Accessibility:**
This change directly addresses a significant WCAG (Web Content Accessibility Guidelines) violation by providing text alternatives for non-text content, ensuring all users can interpret the research data.

---
*PR created automatically by Jules for task [1619052941796323285](https://jules.google.com/task/1619052941796323285) started by @jeremymiles*