### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2026-04-03 - Add dynamic alt text to loop-generated plots
+**Learning:** When generating multiple plots programmatically within a loop in R (e.g., using ggplot2 in a Quarto document), using a static string for alt text results in identical, unhelpful descriptions for all plots, reducing screen reader accessibility. Furthermore, failing to iterate over unique values causes redundant plot generation.
+**Action:** Use `paste()` or `glue()` to dynamically construct the `alt` text attribute within `labs()` (e.g., `labs(alt = paste("Plot for", variable))`), ensuring each generated plot has a specific and descriptive accessible label. Additionally, use `unique()` on the loop iterator (e.g., `for (val in unique(data))`) to optimize performance and prevent duplicate plot creation.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "diagnostic tool")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
**💡 What:**
Added dynamic `alt` text to the scatter plots generated in a loop within `adhd_adults_diagnosis.qmd`. Also optimized the loop condition from `for (name_1 in d_ss_long$name)` to `for (name_1 in unique(d_ss_long$name))`.

**🎯 Why:**
Previously, the `ggplot` loop was generating redundant plots because it wasn't iterating over the `unique()` values of the dataframe column, which degrades user experience. Furthermore, iterating over all plots without `alt` text provides a poor experience for users relying on screen readers.

**📸 Before/After:**
*Before:*
```R
for (name_1 in d_ss_long$name) {
...
    labs(
      shape = "Neurotypical only"
    ) +
...
```

*After:*
```R
for (name_1 in unique(d_ss_long$name)) {
...
    labs(
      shape = "Neurotypical only",
      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "diagnostic tool")
    ) +
...
```

**♿ Accessibility:**
This change improves screen reader compatibility by giving each uniquely generated plot a descriptive, dynamic `alt` text label (e.g., "Scatter plot of Sensitivity vs Specificity for Self-Report Questionnaire diagnostic tool"). Screen reader users can now contextually differentiate between the multiple diagnostic tool plots on the page.

---
*PR created automatically by Jules for task [5837152301513264542](https://jules.google.com/task/5837152301513264542) started by @jeremymiles*