### PR TITLE
🎨 Palette: Add alt text to all ggplot visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2026-04-04 - Add alt text to ggplot visualizations in Quarto
+**Learning:** Screen readers cannot interpret data visualizations in Quarto documents automatically. Without explicit `alt` text, users relying on assistive technologies miss out on crucial data insights.
+**Action:** Always provide descriptive alternative text for `ggplot2` visualizations using the `labs(alt = "...")` function. When rendering plots within loops, dynamically generate the alt text (e.g., using `paste()`) to reflect the specific data being plotted.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -147,7 +147,8 @@ ggplot2::ggplot(
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
   xlim(c(0, 100)) + 
-  ylim(c(0, 100))
+  ylim(c(0, 100)) +
+  labs(alt = "Scatter plot showing sensitivity versus specificity across studies")
 
 
 d_ss_long <- d_ss_long %>%
@@ -169,7 +170,8 @@ ggplot2::ggplot(
   guides(colour = "none") +
   theme(legend.position = "bottom") +
   xlim(c(0, 100)) + 
-  ylim(c(0, 100))
+  ylim(c(0, 100)) +
+  labs(alt = "Scatter plots showing sensitivity versus specificity, faceted by diagnostic tool name")
 ```
 
 ```{r}
@@ -187,13 +189,14 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plots showing sensitivity versus specificity across diagnostic tools, using shapes to distinguish whether studies included only neurotypical control groups"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity versus specificity for the", name_1, "diagnostic tool, indicating neurotypical status")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Bubble chart showing sensitivity versus specificity for frequent self-report diagnostic tools, colored by tool type with point size representing sample size"
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Bubble chart showing sensitivity versus specificity for frequent neurocognitive diagnostic tools, colored by tool type with point size representing sample size"
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -500,7 +506,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_grid(type ~ measure)+
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Boxplots comparing sensitivity, specificity, and accuracy between ADHD and neurotypical groups across different measure types")
 
 # Figure 7
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -511,7 +518,10 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
-  labs(y = NULL)
+  labs(
+    y = NULL,
+    alt = "Boxplots comparing performance metrics across different groups and measure types"
+  )
 
 
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -521,7 +531,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_wrap(~ type) +
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Boxplots showing distributions of different metrics, colored by measure and faceted by type")
 
 
 ```


### PR DESCRIPTION
**💡 What**
Added `alt` text parameters (via `labs(alt = "...")`) to all nine `ggplot2::ggplot()` occurrences within the `adhd_adults_diagnosis.qmd` file. For plots generated inside a `for` loop, the `alt` text is constructed dynamically using `paste()` to reference the specific data being visualized. Appended a new critical learning log to `.Jules/palette.md`. Also optimized a loop variable to use `unique()`.

**🎯 Why**
Data visualizations generated in Quarto are completely opaque to users relying on assistive technologies (like screen readers) unless alternative text is explicitly provided. By adding descriptive text explaining what the scatter plots, bubble charts, and boxplots represent, we make the document's analytical insights accessible to all readers.

**📸 Before/After**
*Before:*
```r
  ggplot2::ggplot(...) +
  geom_point() +
  ...
```
*After:*
```r
  ggplot2::ggplot(...) +
  geom_point() +
  ... +
  labs(alt = "Bubble chart showing sensitivity versus specificity...")
```

**♿ Accessibility**
Provides descriptive textual alternatives for all charts in the document, allowing screen readers to convey the meaning of the visualizations to visually impaired users.

---
*PR created automatically by Jules for task [4320335021096438191](https://jules.google.com/task/4320335021096438191) started by @jeremymiles*