### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Use dynamic alt text for data visualizations in loops
+**Learning:** When generating plots (like `ggplot2`) within a loop, using a single static `alt` description for all generated images reduces accessibility because screen reader users cannot distinguish between the different charts.
+**Action:** Always generate dynamic `alt` text using string concatenation (e.g., `paste()`) to reflect the specific iteration's data in the `labs(alt = ...)` function.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "grouped by Neurotypical only")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** 
Updated the `ggplot2` visualization generation in `adhd_adults_diagnosis.qmd` to include a dynamically generated `alt` description in the `labs()` layer and ensure that charts are only created once per unique category.

🎯 **Why:** 
When generating multiple plots inside a loop, providing a static description (or lacking one entirely) severely degrades the experience for screen reader users, who will not be able to identify which specific metric or sub-group the plot is currently displaying. The change to loop over `unique()` also ensures redundant charts are not generated, streamlining the UI and performance.

📸 **Before/After:**
- **Before:** No `alt` text attribute was provided inside the `ggplot2` generated in the "separate charts" loop (lines 195-215). The loop also iterated over all rows of `d_ss_long` redundantly instead of `unique()` categories.
- **After:** `alt` text is dynamically constructed using `paste()` to specifically include the `name_1` tool identifier being plotted, and redundant processing is avoided.

♿ **Accessibility:**
Screen readers can now accurately announce each generated plot with specific context ("Scatter plot of Sensitivity vs Specificity for [Tool Name] grouped by Neurotypical only"), making the data visualisations significantly more accessible to users with visual impairments.

---
*PR created automatically by Jules for task [10840984759108254567](https://jules.google.com/task/10840984759108254567) started by @jeremymiles*