### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Use dynamic alt text for looped plots in ggplot2
+**Learning:** Hardcoded alt text or no alt text on images created by `ggplot` inside a loop will either be repetitively unhelpful or simply absent, significantly hindering screen reader accessibility.
+**Action:** When creating plots inside loops, dynamically generate the alternative text within `labs(alt = ...)` (e.g. using `paste()`) to provide specific, contextual information for each plot variant.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Added dynamically generated `alt` text to the scatter plots created inside a `for` loop in `adhd_adults_diagnosis.qmd`, and optimized the loop iterator to use `unique(d_ss_long$name)`.

🎯 Why: Generating identically described (or undescribed) plots in a loop hinders accessibility for screen reader users and creates redundant charts. By providing specific text for each plot variant, we enhance the overall accessibility and user experience of the compiled document.

📸 Before/After: Before, all plots lacked alt text. After, each plot is labeled with `Scatter plot of sensitivity vs specificity for [study name] studies`.

♿ Accessibility: Specifically improves the experience for users who rely on screen readers by ensuring meaningful descriptions are available for images generated programmatically in the R Markdown/Quarto document.

---
*PR created automatically by Jules for task [12223309310842827469](https://jules.google.com/task/12223309310842827469) started by @jeremymiles*