### PR TITLE
🎨 Palette: Add dynamic alt text to generated scatter plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in Generated Plots
+**Learning:** When generating plots inside a loop, static alt text fails to accurately describe each unique image to screen readers.
+**Action:** Always use dynamic text functions (e.g., `paste()`) in `labs(alt = ...)` to generate descriptive alt text that reflects the specific iteration's data or focus.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, distinguishing neurotypical only groups.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Modified the `for` loop in `adhd_adults_diagnosis.qmd` that generates individual scatter plots to:
1. Iterate over `unique(d_ss_long$name)` instead of every row.
2. Include a dynamically generated `alt` text attribute in the `labs()` function using `paste()`.

### 🎯 Why
When generating data visualizations inside a loop, using a single static `alt` text description means screen readers get the exact same description for every single plot, rendering them useless for visually impaired users. Additionally, iterating over `d_ss_long$name` directly without `unique()` caused the loop to generate redundant copies of the plots for every single row in the dataframe.

### 📸 Before/After
**Before:**
```r
for (name_1 in d_ss_long$name) {
  plot <- ggplot2::ggplot(...) +
    # ...
    labs(
      shape = "Neurotypical only"
    )
}
```

**After:**
```r
for (name_1 in unique(d_ss_long$name)) {
  plot <- ggplot2::ggplot(...) +
    # ...
    labs(
      shape = "Neurotypical only",
      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, distinguishing neurotypical only groups.")
    )
}
```

### ♿ Accessibility
This change ensures that screen readers receive a uniquely descriptive string for every single plot generated by the loop, greatly improving the accessibility of the Quarto document's HTML output.

---
*PR created automatically by Jules for task [1095469851386957485](https://jules.google.com/task/1095469851386957485) started by @jeremymiles*