### PR TITLE
🎨 Palette: Dynamic alt text for loop-generated plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic alternative text for generated plots
+**Learning:** Hardcoded single static alternative texts for plots dynamically generated inside loops using `ggplot2` in RMarkdown are unhelpful and inaccessible for screen readers. They cannot convey the distinction between variations of the same chart type.
+**Action:** When creating `ggplot2` visualizations inside a loop, dynamically generate the `alt` parameter using string operations (e.g., `paste()`) incorporating loop variables to reflect the specific iteration's data precisely.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamic alternative (`alt`) text to the scatter plots generated via loop in `adhd_adults_diagnosis.qmd` using the `labs(alt = ...)` function. Also updated the loop to iterate over `unique(d_ss_long$name)` instead of the raw column to avoid outputting redundant, duplicate charts for every row in the dataset.

### 🎯 Why
When standard charts are generated dynamically via a loop in RMarkdown, screen readers receive unhelpful, identical (or completely missing) context if the `alt` parameter isn't supplied or is hardcoded. By dynamically assigning descriptive `alt` text and preventing redundant duplicate plot rendering, we substantially improve the usability and accessibility of the compiled HTML document for assistive technologies.

### 📸 Before/After
**Before:** No `alt` text for generated `ggplot2` plots in the loop; script printed identical duplicate plots repeatedly for every row in the dataset because the loop iterated over `d_ss_long$name`.
**After:** Each unique plot generated in the loop receives a descriptive, context-specific `alt` text (e.g., "Scatter plot of sensitivity versus specificity for [Name]"). The loop correctly iterates only over `unique(d_ss_long$name)`.

### ♿ Accessibility
This explicitly addresses the accessibility of purely visual data (charts/graphs) generated dynamically in Quarto/RMarkdown documents. Screen readers will now be able to correctly identify and distinguish between different variations of the scatter plots generated in the output HTML.

---
*PR created automatically by Jules for task [5531360055126636246](https://jules.google.com/task/5531360055126636246) started by @jeremymiles*