### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 loops

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in Plots
+**Learning:** When generating multiple plots in a loop (e.g., using `ggplot2`), it's essential to dynamically generate the `alt` text to accurately describe the specific data shown in each plot. Hardcoding a static string results in repetitive and less informative alternative text, hindering accessibility for screen reader users.
+**Action:** Always use dynamic string construction (like `paste()`) to incorporate iteration variables or specific data characteristics into the `alt` text when generating plots programmatically.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity and specificity for", name_1, "comparing diagnostic tools")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
**💡 What:**
Added dynamic alternative (`alt`) text to a `ggplot2` visualization loop in `adhd_adults_diagnosis.qmd` using `labs(alt = ...)` and modified the loop iterator to use `unique(d_ss_long$name)`.

**🎯 Why:**
When plots are generated programmatically in a loop, assigning a static string for `alt` text fails to accurately describe the unique data depicted in each iteration. Screen readers would read the same description for different plots. Furthermore, iterating directly over the long format column resulted in redundantly generating and plotting identical charts, negatively impacting performance and user experience.

**📸 Before/After:**
*Before:* The scatterplots lacked `alt` text descriptions, and the loop generated multiple identical plots due to redundant iterations over the long format dataframe.
*After:* Each unique plot is generated exactly once, and features specific `alt` text (e.g., "Scatter plot of sensitivity and specificity for DIVA comparing diagnostic tools").

**♿ Accessibility:**
The dynamically generated `alt` text ensures that screen reader users are provided with accurate context about the data (the specific diagnosis tool) visualized in each individual plot, greatly improving accessibility for visually impaired users.

---
*PR created automatically by Jules for task [13455137854611562925](https://jules.google.com/task/13455137854611562925) started by @jeremymiles*