### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots for improved accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+
+## 2024-05-24 - Dynamic alt text for iterated plots in Quarto
+**Learning:** When generating multiple plots in a loop (e.g., using a `for` loop in R with ggplot2) within a Quarto or RMarkdown document, setting a single static `alt` text attribute creates redundant, less informative accessibility descriptions for screen readers.
+**Action:** Dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()` in R) using the loop iterator variables to accurately reflect each specific plot's data, ensuring distinct and informative alternative text for every generated visualization.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamically generated `alt` text descriptions to `ggplot2` plots that are created within a loop in the `adhd_adults_diagnosis.qmd` Quarto document. 

### 🎯 Why
When rendering multiple charts iteratively, having a static `alt` text attribute leads to redundant and uninformative descriptions for screen readers. Using `unique(d_ss_long$name)` to iterate, and pasting the specific data subset's name into the `alt` property creates unique, distinct labels that directly reflect each individual plot.

### 📸 Before/After
* **Before:** The plots generated within the `for (name_1 in d_ss_long$name)` loop lacked an explicit `alt` text definition, relying on defaults which are often inaccessible or purely descriptive of the visual geometry rather than the underlying data being presented. Also had a subtle bug where the loop ran multiple times for identical column items.
* **After:** The iterator is wrapped in `unique()` to eliminate redundant iteration. Added `alt = paste("Scatter plot of sensitivity vs specificity for", name_1, "studies")` to the `labs()` call inside the loop, correctly assigning informative text to each plot corresponding to its respective subgroup (e.g., "Scatter plot of sensitivity vs specificity for Biomarker studies").

### ♿ Accessibility
Enhances document accessibility by ensuring that screen reader users can distinguish and comprehend the context of each distinct chart generated within the loop.

---
*PR created automatically by Jules for task [2962779533837666034](https://jules.google.com/task/2962779533837666034) started by @jeremymiles*