### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 loop and fix redundancy

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alternative text to plots in loops
+**Learning:** Generating plots in a loop without dynamic alternative text (alt text) results in multiple images that screen readers either cannot describe or describe identically, severely hindering accessibility for visually impaired users analyzing the data.
+**Action:** Always include dynamically generated `alt` text using `labs(alt = paste(...))` within `ggplot2::ggplot()` calls inside loops to accurately describe each specific plot's contents.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "diagnostic tool")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamic `alt` text generation to the `ggplot2` rendering loop in `adhd_adults_diagnosis.qmd` using `labs(alt = paste(...))` and modified the loop to iterate over `unique(d_ss_long$name)`.

### 🎯 Why
Generating multiple plots in a loop without dynamic alternative text means screen readers will not be able to describe them differently, hindering accessibility for visually impaired users. Additionally, iterating over the entire vector instead of `unique()` values caused redundant plot processing.

### 📸 Before/After
**Before:** No `alt` text in the `labs()` call and the loop used `for (name_1 in d_ss_long$name)`.
**After:** Added `alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "diagnostic tool")` and changed the loop to `for (name_1 in unique(d_ss_long$name))`.

### ♿ Accessibility
Significantly improves accessibility for visually impaired users by allowing screen readers to specifically identify what each generated plot represents.

---
*PR created automatically by Jules for task [13820659895830741389](https://jules.google.com/task/13820659895830741389) started by @jeremymiles*