### PR TITLE
🎨 Palette: Add accessible alt text to ggplot2 visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Use accessible alt text in ggplot2 plots
+**Learning:** Data visualizations without alternative text (alt text) present a major accessibility barrier for users relying on screen readers. This makes charts and graphs completely opaque to those users.
+**Action:** Always add accessible alternative text using the `labs(alt = "...")` function directly within `ggplot2::ggplot()` calls to ensure screen readers can describe the generated plot image. For plots generated in loops, dynamically construct the alt text (e.g., using `paste()`) to reflect the specific iteration's data.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -147,7 +147,8 @@ ggplot2::ggplot(
   xlab("Sensitivity (%)") + 
   ylab("Specificity (%)") +
   xlim(c(0, 100)) + 
-  ylim(c(0, 100))
+  ylim(c(0, 100)) +
+  labs(alt = "Scatter plot showing sensitivity versus specificity across various diagnostic categories.")
 
 
 d_ss_long <- d_ss_long %>%
@@ -168,6 +169,7 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count) +
   guides(colour = "none") +
   theme(legend.position = "bottom") +
+  labs(alt = "Faceted scatter plots showing sensitivity versus specificity, grouped by diagnostic tool with study counts.") +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 ```
@@ -187,7 +189,8 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Faceted scatter plots of sensitivity versus specificity, highlighting studies with neurotypical only control groups."
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
@@ -205,7 +208,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "highlighting neurotypical only studies.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 
@@ -287,7 +291,8 @@ ggplot2::ggplot(
   ggrepel::geom_text_repel(
     aes(label = test_description), max.overlaps = 10, size = 5) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Bubble chart of sensitivity versus specificity for self-report tools, colored by frequent tools and sized by study size."
   ) +
   scale_size_continuous(
     name = "Size", # This sets the legend title
@@ -370,7 +375,8 @@ plot_data %>% ggplot2::ggplot(
   ylab("Specificity (%)") +
   geom_text_repel(aes(label = test_description), max.overlaps = 10, size = 3) +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Bubble chart of sensitivity versus specificity for neuropsychological tools, colored by frequent tools and sized by study size."
   ) + 
   theme(legend.position = "right") +
   xlim(c(0, 100)) + 
@@ -500,7 +506,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_grid(type ~ measure)+
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Faceted box plots showing accuracy and AUC values across different diagnostic tools and control groups.")
 
 # Figure 7
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -511,7 +518,10 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   geom_boxplot() +
   facet_grid(measure ~ type)+
   theme(axis.text.x = element_text(angle = 90, hjust = 1))+
-  labs(y = NULL)
+  labs(
+    y = NULL,
+    alt = "Faceted box plots of accuracy and AUC against control group type, with diagnostic tools as columns."
+  )
 
 
 d_long_both %>% dplyr::filter(!is.na(value)) %>%
@@ -521,7 +531,8 @@ d_long_both %>% dplyr::filter(!is.na(value)) %>%
   )  + 
   geom_boxplot() +
   facet_wrap(~ type) +
-  theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+  labs(alt = "Wrapped faceted box plots comparing accuracy and AUC measures across diagnostic tools.")
 
 
 ```


### PR DESCRIPTION
💡 **What**: Added `alt` text to multiple `ggplot2` visualizations across `adhd_adults_diagnosis.qmd` using the `labs(alt = "...")` function, and appended a critical learning to `.Jules/palette.md`.

🎯 **Why**: Data visualizations rendered without alternative text present a major barrier to users utilizing screen readers. Providing robust alternative text ensures these insights are accessible to everyone, regardless of vision level.

📸 **Before/After**: N/A - Non-visual accessibility change.

♿ **Accessibility**: Enhanced screen reader compatibility for all `ggplot2` charts rendered from `adhd_adults_diagnosis.qmd`. Dynamic generation of alt text used where appropriate (i.e. inside loops) to provide proper context.

---
*PR created automatically by Jules for task [2962893060080879733](https://jules.google.com/task/2962893060080879733) started by @jeremymiles*