### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+
+## 2024-04-19 - Dynamic Alt Text in Generated Plots
+**Learning:** Generating multiple charts inside a loop without dynamic `alt` text provides a poor experience for screen reader users as all images are either announced with the same generic alt text or read without any useful context, making it hard to distinguish charts.
+**Action:** Always inject dynamically generated `alt` text into generated charts within iterative loops, for example using `labs(alt = paste("Scatter plot for", name_1))` in `ggplot2`.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamically generated `alt` text to the scatter plots created in `adhd_adults_diagnosis.qmd` using `labs(alt = ...)` and modified the loop to iterate through `unique(d_ss_long$name)`.

### 🎯 Why
Without dynamic `alt` text, screen readers either receive no useful information or repetitively generic information for each plot generated within the loop, severely hindering users relying on assistive technology from distinguishing and understanding the distinct charts. Using `unique()` also corrects an issue where the loop was iterating over the non-unique name column, potentially generating duplicate plots unnecessarily.

### 📸 Before/After
**Before:**
```r
for (name_1 in d_ss_long$name) {
  plot <- ggplot2::ggplot(...) +
    labs(
      shape = "Neurotypical only"
    )
```

**After:**
```r
for (name_1 in unique(d_ss_long$name)) {
  plot <- ggplot2::ggplot(...) +
    labs(
      shape = "Neurotypical only",
      alt = paste("Scatter plot showing sensitivity versus specificity for", name_1)
    )
```

### ♿ Accessibility
- Dramatically improves screen reader experience by programmatically adding context to visualizations iteratively generated via `ggplot2`.

---
*PR created automatically by Jules for task [13574914029898393203](https://jules.google.com/task/13574914029898393203) started by @jeremymiles*