### PR TITLE
🎨 Palette: Add dynamic alt text to diagnostic tool scatter plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-06-03 - Add dynamic alternative text to plots inside loops
+**Learning:** Generating plots within a loop without dynamically assigned `alt` text can lead to either missing or duplicated descriptions for all visual iterations, rendering the generated document inaccessible for screen reader users relying on distinct context.
+**Action:** When generating `ggplot2` plots inside loops in R Markdown/Quarto, always include `alt = ...` within `labs()` and construct a dynamic string (e.g. `paste()`) that includes the looping variable to ensure unique, contextual descriptions.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamic `alt` text descriptions to the `ggplot2` scatter plots generated in a `for` loop inside `adhd_adults_diagnosis.qmd`. The iteration vector was also updated from `d_ss_long$name` to `unique(d_ss_long$name)`.

### 🎯 Why
When generating plots inside a loop in R Markdown/Quarto, lacking dynamically assigned `alt` text leads to missing or duplicated descriptions for the output visuals. This is problematic for screen reader accessibility. I also updated the loop logic to use `unique()` which prevents redundant generation of identical plots for every row in the dataset, significantly improving rendering efficiency and output document clarity.

### 📸 Before/After
- **Before**: `labs(shape = "Neurotypical only")` inside a loop evaluating `for (name_1 in d_ss_long$name)`
- **After**: `labs(shape = "Neurotypical only", alt = paste("Scatter plot of sensitivity versus specificity for", name_1))` inside a loop evaluating `for (name_1 in unique(d_ss_long$name))`

### ♿ Accessibility
The added `alt` attribute strictly ensures that screen reader users are provided with clear, contextual alternative descriptions (e.g. "Scatter plot of sensitivity versus specificity for [Diagnostic Tool]") for each dynamically rendered visual element in the document.

---
*PR created automatically by Jules for task [17886349792249457984](https://jules.google.com/task/17886349792249457984) started by @jeremymiles*