### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-18 - Dynamic Alt Text in ggplot2 loops
+**Learning:** When generating multiple `ggplot2` visualizations inside a loop, static alt text fails to describe the specific data being presented in each iteration, which degrades the experience for screen reader users.
+**Action:** Use dynamic alt text generation via `labs(alt = paste(...))` to ensure each plot's alternative text accurately reflects the unique context or data subset of that specific iteration.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamically generated alt text to the `ggplot2` charts produced within a `for` loop in `adhd_adults_diagnosis.qmd`. Also optimized the loop itself to prevent redundant rendering by using `unique()`.

### 🎯 Why
Screen reader users need accurate descriptions of visual data. When a loop generates multiple plots, a static alt text fails to contextualize each specific iteration. Passing a dynamically generated string to `labs(alt = ...)` solves this. In the process, I noticed the loop was re-running redundantly for every single row in the data frame (because it iterated over `d_ss_long$name` rather than `unique(d_ss_long$name)`), which I also fixed to prevent unnecessary rendering.

### 📸 Before/After
- **Before:** `ggplot2` visualizations in the loop lacked `alt` text, rendering them invisible or contextless to screen readers. The loop also redundantly re-ran for every row.
- **After:** Each `ggplot2` visualization is provided with specific, dynamic alt text explaining what is being plotted (e.g., "Scatter plot showing sensitivity versus specificity for ASRS"). The loop executes cleanly via `unique()`.

### ♿ Accessibility
Improves accessibility for visually impaired users by ensuring that dynamically generated data visualizations are audibly distinct and contextually accurate when read by a screen reader.

---
*PR created automatically by Jules for task [14183742982987198674](https://jules.google.com/task/14183742982987198674) started by @jeremymiles*