### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-18 - Dynamic Alt Text in Generated Charts
+**Learning:** When generating multiple plots dynamically (like with `ggplot2` in a loop within an RMarkdown/Quarto document), static `alt` text fails to describe the specific context of each individual chart, which degrades the experience for screen reader users trying to distinguish them.
+**Action:** Always dynamically generate the `alt` text attribute in `labs()` (e.g., using `paste()` with the loop's current iteration variable) to provide specific, contextual descriptions for each dynamically generated plot.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity and specificity for the diagnostic tool", name_1, "with points distinguishing neurotypical inclusion.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Added dynamic alternative text (`alt` attribute in `labs()`) to the dynamically generated `ggplot2` scatter plots within the `adhd_adults_diagnosis.qmd` file. Also updated the loop iterator to use `unique(d_ss_long$name)` to prevent rendering duplicate charts.
🎯 Why: Iterating over every row of the long-format dataframe was extremely inefficient and generated duplicate charts. More importantly, when generating multiple charts in a loop, a static alt text fails to provide specific context. Screen reader users would hear the same description for every single chart, making them indistinguishable. Dynamic alt text provides the specific diagnostic tool name for each plot.
📸 Before/After:
Before: The charts generated in the `for` loop had no `alt` text attribute in `labs()`, and the loop ran redundantly for every row in `d_ss_long`.
After: The loop efficiently iterates only over unique tools, and each generated scatter plot has a specific `alt` text attribute like "Scatter plot showing sensitivity and specificity for the diagnostic tool ASRS with points distinguishing neurotypical inclusion."
♿ Accessibility: Significantly improves the experience for users utilizing screen readers by accurately describing each specific chart dynamically generated in the Quarto document.

---
*PR created automatically by Jules for task [3569434140577671519](https://jules.google.com/task/3569434140577671519) started by @jeremymiles*