### PR TITLE
🎨 Palette: Add dynamic alt text to loop-generated ggplot charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alt text to ggplot2 charts generated in loops
+**Learning:** When generating multiple plots within a loop (e.g., using `ggplot2`), setting a static `alt` text in `labs()` results in identical descriptions for different charts, reducing accessibility for screen reader users. Furthermore, iterating over all elements of a vector instead of unique elements leads to redundant plot generation and performance issues.
+**Action:** Always use dynamic `alt` text in loop-generated plots (e.g., using `paste()` with the loop variable) and ensure loops iterate over unique values (e.g., using `unique()`) to improve both accessibility and performance.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:**
Added dynamic alternative (`alt`) text to `ggplot2` charts generated within a `for` loop in `adhd_adults_diagnosis.qmd`. Modified the loop to iterate over unique values of the target column (`unique(d_ss_long$name)`) instead of all rows.

🎯 **Why:**
1. **Accessibility:** Previously, any charts generated within this loop had identical or missing `alt` text descriptions, reducing accessibility. By generating a dynamic `alt` text (e.g., "Scatter plot of sensitivity versus specificity for [Name]"), screen reader users can accurately distinguish the context of each separate chart.
2. **Performance/Bug Fix:** The previous loop condition (`for (name_1 in d_ss_long$name)`) iterated over *every row* in the column rather than the *unique categories*. For a dataframe with hundreds of rows, this would incorrectly attempt to generate and print hundreds of duplicate charts.

📸 **Before/After:**
*Before:*
```r
for (name_1 in d_ss_long$name) {
  plot <- ggplot2::ggplot(...) +
    ...
    labs(shape = "Neurotypical only")
```
*After:*
```r
for (name_1 in unique(d_ss_long$name)) {
  plot <- ggplot2::ggplot(...) +
    ...
    labs(
      shape = "Neurotypical only",
      alt = paste("Scatter plot of sensitivity versus specificity for", name_1)
    )
```

♿ **Accessibility:**
Screen readers will now read accurate, context-specific descriptions for every chart generated in the loop, complying with accessibility best practices.

---
*PR created automatically by Jules for task [12013772663838218654](https://jules.google.com/task/12013772663838218654) started by @jeremymiles*