### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 loop

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Use dynamic alt text for ggplot2 generated in loops
+**Learning:** When generating multiple `ggplot2` plots inside a loop, static `alt` text in `labs(alt = ...)` fails to describe the specific data shown in each individual plot, degrading the experience for screen reader users.
+**Action:** Use string concatenation functions like `paste()` to dynamically generate the `alt` text in `labs(alt = ...)` to reflect the specific iteration's data, ensuring each plot has descriptive and unique alternative text.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "diagnostic tool")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamic `alt` text to the `ggplot2` visualizations generated inside the loop in `adhd_adults_diagnosis.qmd`. The loop iterator was also updated to use `unique(d_ss_long$name)` instead of iterating over every single row of the long dataframe.

### 🎯 Why
When generating multiple `ggplot2` plots inside a loop, using static `alt` text or missing `alt` text completely fails to describe the specific data shown in each individual plot, degrading the experience for screen reader users. Furthermore, iterating over a long-format dataframe column directly causes the same plots to be generated redundantly.

### 📸 Before/After
**Before:**
- Loop generated redundant identical plots because the iterator did not use `unique()`.
- Generated plots lacked alternative text describing the specific diagnostic tool.

**After:**
- Loop iterator uses `unique()` to only generate one plot per diagnostic tool.
- Generated plots have dynamic alternative text like: "Scatter plot of Sensitivity vs Specificity for [Tool Name] diagnostic tool".

### ♿ Accessibility
This change improves accessibility for screen reader users by providing descriptive, unique alternative text for each dynamically generated plot, allowing them to distinguish between the different diagnostic tools being visualized.

---
*PR created automatically by Jules for task [16512779691768534688](https://jules.google.com/task/16512779691768534688) started by @jeremymiles*