### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in Generated Plots
+**Learning:** Generating multiple plots iteratively without dynamic alt text creates an inaccessible experience for screen reader users, who will just hear generic or repetitive descriptions for different charts.
+**Action:** Always add dynamic alt text using `labs(alt = ...)` inside plot generation loops (e.g., using `paste()` to incorporate the iteration variable) to ensure each plot is uniquely identifiable and descriptive.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "diagnostic tools in ADHD adults")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** 
Added dynamic alternative text (`alt`) to `ggplot2` charts that are generated iteratively within a `for` loop in `adhd_adults_diagnosis.qmd`. Also corrected the loop iterator to prevent duplicate rendering of the same charts.

🎯 **Why:**
When generating multiple plots in a loop, hardcoding or omitting `alt` text creates a confusing and inaccessible experience for screen reader users, as every plot would sound identical or lack context. Providing a dynamic description based on the iteration variable clearly identifies each unique visualization. Fixing the loop iterator from `d_ss_long$name` to `unique(d_ss_long$name)` also stops the script from fruitlessly drawing identical charts thousands of times, reducing scrolling fatigue and drastically improving rendering performance.

📸 **Before/After:**
*Before:*
- Hundreds of identical charts generated per diagnostic category.
- Generated plots lacked alternative text attributes.
*After:*
- Exactly one chart generated per diagnostic category.
- `alt="Scatter plot of sensitivity versus specificity for [Category] diagnostic tools in ADHD adults"` correctly applied to each iteration.

♿ **Accessibility:**
Screen readers can now uniquely identify and read descriptive summaries for each auto-generated scatter plot, ensuring users with visual impairments can understand the context of the displayed data without relying on adjacent text alone.

---
*PR created automatically by Jules for task [7939686563540180958](https://jules.google.com/task/7939686563540180958) started by @jeremymiles*