### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Dynamically generate alt text for iterative data visualizations
+**Learning:** Hardcoding a static `alt` text attribute when generating multiple plots inside a loop results in screen readers reading the exact same description for different charts, causing confusion and missing context.
+**Action:** When creating multiple plots iteratively (e.g., in a `for` loop), construct dynamic `alt` text using string concatenation functions (e.g., `paste()`) incorporating loop variables to provide distinct, accurate descriptions for each generated plot.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity versus specificity for", name_1, "studies, differentiated by neurotypical only shape.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
**💡 What**
Added dynamic `alt` text to the scatter plots generated iteratively in a `for` loop in `adhd_adults_diagnosis.qmd`. Also optimized the loop iterator from `d_ss_long$name` to `unique(d_ss_long$name)` to prevent rendering redundant, identical charts.

**🎯 Why**
Previously, the `for` loop generated multiple distinct plots for different studies but lacked alternative text, making them completely inaccessible to screen readers. If static text was added, all charts would sound the same. Dynamically constructing the `alt` text using the loop's context ensures users with visual impairments understand exactly which subset of data they are currently examining. Furthermore, the loop iterated over every row in `d_ss_long`, unnecessarily rebuilding identical charts hundreds of times; iterating over `unique` study names fixes this bug.

**📸 Before/After**
*Visual appearance is unchanged.*

**♿ Accessibility**
- Added dynamically generated ARIA alternative text (`labs(alt = ...)` in ggplot) to looped scatter plots for proper screen reader comprehension.

---
*PR created automatically by Jules for task [17586825695182194275](https://jules.google.com/task/17586825695182194275) started by @jeremymiles*