### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots in loops

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Ensure dynamic alt text for accessible generated plots in loops
+**Learning:** When using `ggplot2` inside a `for` loop to generate multiple related plots, hardcoded static `alt` text causes screen readers to redundantly announce the exact same description for each distinct image, frustrating and confusing users navigating the document.
+**Action:** Always dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()` or `glue::glue()`) to reflect the specific context or data slice of that iteration, ensuring screen reader users receive accurate and distinct context for every plot.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, shaped by Neurotypical only status.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:**
Added dynamically generated `alt` text to the `ggplot2` figures generated within a `for` loop in `adhd_adults_diagnosis.qmd`. Also updated the loop iterator from `d_ss_long$name` to `unique(d_ss_long$name)`.

🎯 **Why:**
Using a static, hardcoded `alt` text description for a series of distinct plots generated in a loop results in screen readers redundantly announcing the exact same description for every image, causing frustration and confusion. Additionally, iterating over `d_ss_long$name` instead of `unique(d_ss_long$name)` redundantly generates identical plots for every row in the dataset instead of one per unique name.

📸 **Before/After:**
*Before:*
```R
for (name_1 in d_ss_long$name) {
  plot <- ggplot2::ggplot(...) +
    labs(
      shape = "Neurotypical only"
    )
```

*After:*
```R
for (name_1 in unique(d_ss_long$name)) {
  plot <- ggplot2::ggplot(...) +
    labs(
      shape = "Neurotypical only",
      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, shaped by Neurotypical only status.")
    )
```

♿ **Accessibility:**
Screen reader users will now hear accurate, distinct context for every plot generated by the loop, greatly improving their ability to understand and navigate the document's visualizations.

---
*PR created automatically by Jules for task [16767752884818127429](https://jules.google.com/task/16767752884818127429) started by @jeremymiles*