### PR TITLE
🎨 Palette: Add alt text to diagnostic plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in ggplot2 visualizations
+**Learning:** Quarto and RMarkdown visualizations created with `ggplot2` often lack accessibility for screen readers because they omit `alt` text. While adding static `alt` text via `labs(alt = "...")` works for single plots, dynamically generated plots in loops require dynamic `alt` text to accurately describe the specific data being visualized.
+**Action:** Use `labs(alt = "...")` inside `ggplot2::ggplot()` to add alt text. For plots generated in loops, construct the `alt` text dynamically (e.g., using `paste()`) to incorporate the current loop iteration variable, ensuring the description matches the specific data rendered in that iteration.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -187,13 +187,14 @@ ggplot2::ggplot(
   facet_wrap(~ name_with_count, nrow = 2) +
   guides(colour = "none") +
   labs(
-    shape = "Neurotypical only"
+    shape = "Neurotypical only",
+    alt = "Scatter plot showing sensitivity vs specificity for different ADHD diagnostic tests, separated by neurotypical status"
   ) +
   xlim(c(0, 100)) + 
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +206,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity vs specificity for", name_1, "diagnostic test, separated by neurotypical status")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
**💡 What**
Added missing `alt` attributes to the `ggplot2` visualizations in `adhd_adults_diagnosis.qmd`. Specifically, added static `alt` text to the overarching Figure 8 plot and implemented dynamic `alt` text generation using `paste()` within the `for` loop that generates individual diagnostic charts. Additionally, I modified the `for` loop iterator to use `unique(d_ss_long$name)` instead of iterating over every row in the column.

**🎯 Why**
Visualizations created with `ggplot2` omit `alt` text by default, rendering them inaccessible to users relying on screen readers. Generating dynamic `alt` text in loops is critical for ensuring that each individual chart accurately describes the data it represents. 

Furthermore, iterating directly over the data frame column (`d_ss_long$name`) caused the loop to generate hundreds of duplicate plots (one for every row in the dataset). Using `unique()` drastically improves rendering efficiency and prevents the user from being overwhelmed by duplicate visualizations in the final output.

**📸 Before/After**
*Before:* `labs(shape = "Neurotypical only")` inside loops generated visualizations without accessible descriptions, and the loop executed redundantly for every row.
*After:* `labs(shape = "Neurotypical only", alt = paste("Scatter plot showing sensitivity vs specificity for", name_1, "diagnostic test, separated by neurotypical status"))` ensuring screen readers receive accurate context, and the loop executes efficiently using `unique()`.

**♿ Accessibility**
Improves accessibility for visually impaired users by ensuring all generated scatter plots in the document are accompanied by descriptive, context-aware alternative text, allowing screen readers to convey the meaning of the data visualizations.

---
*PR created automatically by Jules for task [7806478791262967651](https://jules.google.com/task/7806478791262967651) started by @jeremymiles*