### PR TITLE
🎨 Palette: Add dynamic alt text to generated scatter plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in Generated Visualizations
+**Learning:** When generating multiple visualizations in a loop (like `ggplot2` in R), static alt text makes all plots sound identical to screen readers, destroying context.
+**Action:** Always dynamically generate `alt` text using iteration variables (e.g., `labs(alt = paste("Scatter plot showing sensitivity vs specificity for", name_1))`) to ensure each generated plot is uniquely identifiable for screen reader users.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -193,7 +193,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -205,7 +205,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity vs specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** Added dynamically generated `alt` text to the `ggplot2` scatter plots generated within a loop in `adhd_adults_diagnosis.qmd`. Also optimized the loop iterator to use `unique(d_ss_long$name)` to avoid redundant rendering.

🎯 **Why:** To ensure that each scatter plot is uniquely identifiable for screen reader users and to optimize rendering by avoiding repeated plot generation.

📸 **Before/After:** Not a visual change.

♿ **Accessibility:** Screen readers will now read out the specific instrument name for each plot instead of identical default text or no text at all.

---
*PR created automatically by Jules for task [3275801768932420142](https://jules.google.com/task/3275801768932420142) started by @jeremymiles*