### PR TITLE
🎨 Palette: Improve accessibility by using colorblind-friendly color in forest plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -148,7 +148,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -176,7 +176,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
💡 **What**
Changed the hardcoded basic color (`"red"`) to a colorblind-friendly color (`"#D55E00"`, vermilion from the Okabe-Ito palette) for the summary polygons (`addpoly`) in both the Sensitivity and Specificity forest plots within the `adhd_adult_meta_anlaysis.qmd` file.

🎯 **Why**
Using basic, hardcoded colors like red and green can make data visualizations difficult or impossible to interpret for users with color vision deficiencies (such as protanopia or deuteranopia). Switching to an accessible, colorblind-friendly palette ensures the data is easily readable and distinct for all users.

📸 **Before/After**
* **Before:** `col = "red"` in `addpoly` calls.
* **After:** `col = "#D55E00"` in `addpoly` calls.

♿ **Accessibility**
This change improves accessibility for users with color blindness by utilizing a high-contrast, universally distinguishable color (vermilion) from the Okabe-Ito palette, instead of a pure standard red.

---
*PR created automatically by Jules for task [506906689795997797](https://jules.google.com/task/506906689795997797) started by @jeremymiles*