### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 loop

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alt text to ggplot2 in loops
+**Learning:** When generating multiple plots in a loop using ggplot2, using a static alt text description for all plots reduces accessibility for screen reader users, as they cannot distinguish between the different charts.
+**Action:** Use `unique(df$column)` in the loop iterator and dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()`) to reflect the specific iteration's data, ensuring each plot has a unique and descriptive alternative text.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity vs Specificity for", name_1, "studies, shaped by whether they are neurotypical only.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 **What:** Added dynamically generated `alt` text to the `ggplot2` charts rendered within a loop in `adhd_adults_diagnosis.qmd`. Also corrected the loop iterator to use `unique(d_ss_long$name)` to prevent rendering duplicate charts.

🎯 **Why:** To improve accessibility for screen reader users by ensuring each generated chart has a distinct, descriptive alternative text rather than a single static text or none at all. Correcting the iterator also prevents redundant plot generation.

📸 **Before/After:** Not a visual change, but the generated HTML will now include descriptive `alt` attributes on the embedded images (e.g., "Scatter plot of Sensitivity vs Specificity for [Name] studies...").

♿ **Accessibility:** Screen readers can now accurately describe each plot generated by the loop, providing context about the specific subset of data being visualized.

---
*PR created automatically by Jules for task [4951331467895726001](https://jules.google.com/task/4951331467895726001) started by @jeremymiles*