### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 charts generated in loops

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alt text to generated plots in loops
+**Learning:** Generating multiple `ggplot2` plots in a loop without dynamic alt text results in identical or missing descriptions for all plots, which severely limits accessibility for users relying on screen readers.
+**Action:** When generating `ggplot2` plots within a loop, always dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()`) to accurately reflect the specific iteration's data and context.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of Sensitivity versus Specificity for", name_1, "studies, distinguishing between Neurotypical only and other samples.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: 
Added dynamic `alt` text descriptions to the `ggplot2` scatter plots generated inside the `for` loop in `adhd_adults_diagnosis.qmd` using `labs(alt = paste(...))`. I also improved the efficiency of the loop by iterating over `unique(d_ss_long$name)` instead of every row in the dataset.

🎯 Why: 
Generating multiple data visualizations inside a loop without dynamic alt text results in either missing descriptions or identical descriptions for all plots, which makes it impossible for screen reader users to distinguish between the different charts. Using `unique()` prevents the loop from running redundantly and generating duplicate outputs.

📸 Before/After: 
*Before:* The `ggplot` loop did not specify an `alt` attribute, making all output figures lack contextual alt text.
*After:* Each plot now receives a dynamic alt text description, e.g., "Scatter plot of Sensitivity versus Specificity for Self-Report Questionnaire studies, distinguishing between Neurotypical only and other samples."

♿ Accessibility: 
This ensures that users relying on screen readers receive accurate and contextual descriptions of each dynamically generated chart, significantly improving the inclusivity of the rendered document.

---
*PR created automatically by Jules for task [998988146991870094](https://jules.google.com/task/998988146991870094) started by @jeremymiles*