### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alt text to ggplot2 charts
+**Learning:** Generated plots without alt text are inaccessible to screen readers. When generating plots inside a loop, static alt text is insufficient as the context changes.
+**Action:** Always add dynamic `alt` text to `labs()` in `ggplot2` (e.g., `labs(alt = paste("Scatter plot of sensitivity vs specificity for", name_1))`) when generating visualizations in loops to improve accessibility for Quarto/RMarkdown documents.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What
Added a dynamic `alt` text property to the `labs()` function for `ggplot2` visualizations generated inside a `for` loop in `adhd_adults_diagnosis.qmd`. Also optimized the loop condition from `for (name_1 in d_ss_long$name)` to `for (name_1 in unique(d_ss_long$name))`.

🎯 Why
When generating multiple plots inside a loop, static alt text is insufficient as the context of each plot changes. Adding dynamic text using `paste()` ensures that screen readers can accurately interpret the content of each specific visualization. Furthermore, because the dataframe `d_ss_long` is in "long" format, looping over every row's `name` caused the same chart to be generated multiple times redundantly. Using `unique()` resolves this bug and dramatically improves the reading experience.

📸 Before/After
Before: The loop generated duplicate, inaccessible plots without alternative text.
After: The loop correctly generates one plot per category, and each plot contains descriptive, context-specific alternative text (e.g., "Scatter plot of sensitivity versus specificity for Self-Report Questionnaire studies").

♿ Accessibility
Improves accessibility for users relying on screen readers by ensuring every generated plot has a meaningful, descriptive `alt` tag.

---
*PR created automatically by Jules for task [2546659170197712858](https://jules.google.com/task/2546659170197712858) started by @jeremymiles*