### PR TITLE
🎨 Palette: Add accessible alt text to ggplot visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic accessible alt text to ggplot visualizations
+**Learning:** Screen readers and other assistive technologies rely on `alt` text to interpret images. When rendering visualizations in a loop (e.g., using `ggplot2`), hardcoding static `alt` text provides insufficient context, and iterating over redundant data values instead of unique values reduces generation performance.
+**Action:** Always add dynamic `alt` text to `ggplot2` visualizations using `labs(alt = ...)` (e.g., `paste("Scatter plot showing sensitivity vs specificity for", name_1)`) to provide precise context for each iteration. Additionally, use `unique(column)` when iterating over dataframe columns to optimize plot generation.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity vs specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
### 💡 What
Added dynamic `alt` text to the `ggplot2` visualization generated within a loop in `adhd_adults_diagnosis.qmd`. Additionally, optimized the loop to iterate over `unique(d_ss_long$name)` instead of the raw column containing redundant entries.

### 🎯 Why
When generating multiple plots dynamically, failing to provide `alt` text renders the visualizations inaccessible to screen readers and assistive technologies. Furthermore, iterating over a non-unique column in a "long" format dataframe causes redundant plot generation, reducing performance.

### 📸 Before/After
**Before:**
- Loop: `for (name_1 in d_ss_long$name) {` (Redundant processing)
- Plot missing `alt` text in `labs()`.

**After:**
- Loop: `for (name_1 in unique(d_ss_long$name)) {` (Optimized)
- Plot includes dynamic `alt` text: `labs(..., alt = paste("Scatter plot showing sensitivity vs specificity for", name_1))`

### ♿ Accessibility
This micro-enhancement significantly improves accessibility by ensuring that every dynamically generated plot has a descriptive and context-aware `alt` text attribute, allowing screen readers to accurately convey the visualization's purpose to users.

---
*PR created automatically by Jules for task [4898650571952112248](https://jules.google.com/task/4898650571952112248) started by @jeremymiles*