### PR TITLE
🎨 Palette: Add dynamic alt text to generated diagnostic charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Add dynamic alt text to ggplot2 charts generated in loops
+**Learning:** When generating multiple data visualizations (like `ggplot2` plots) within a loop, using a single static alt text description for all plots fails to describe the specific data shown in each iteration, reducing accessibility for screen reader users.
+**Action:** Always dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()` with loop variables) to ensure the alternative text accurately reflects the specific iteration's data and context.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity versus specificity for", name_1, "diagnostic test")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
**💡 What**: Updated the `ggplot2` plotting loop in `adhd_adults_diagnosis.qmd` to inject dynamic `alt` text into each scatter plot using `labs(alt = ...)` and modified the loop iterator to use `unique()` to eliminate redundant iteration processing.

**🎯 Why**: Without dynamic `alt` descriptions, screen readers either receive identical generic text for all plots generated in a loop, or none at all, which makes it impossible for visually impaired users to understand what specific test data is being shown. Additionally, the existing loop over every single row of `d_ss_long` meant massive redundant generation of identical plots; mapping over `unique()` data fixes this bug.

**📸 Before/After**: 
*Before*: No `alt` text parameter passed to `labs()` inside the `for (name_1 in d_ss_long$name)` block. Plot renders endlessly for duplicate rows.
*After*: `labs(..., alt = paste("Scatter plot showing sensitivity versus specificity for", name_1, "diagnostic test"))` ensures distinct alt text for every unique test chart. Loop fixed to `for (name_1 in unique(d_ss_long$name))`.

**♿ Accessibility**: This provides critical context to assistive technologies so users can differentiate the charts and understand the diagnostic tests they refer to without relying on surrounding visual elements.

---
*PR created automatically by Jules for task [1282162569661697479](https://jules.google.com/task/1282162569661697479) started by @jeremymiles*