### PR TITLE
🎨 Palette: Add dynamic alt text to loop-generated ggplots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in ggplot2 Loops
+**Learning:** When rendering plots inside a loop, static alt text limits accessibility as it fails to describe the specific data shown. Additionally, iterating over duplicate values causes redundant rendering which degrades document performance and user experience.
+**Action:** Wrap loop iterators with unique() and use paste() within labs(alt = ...) to dynamically generate descriptive alternative text for each plot.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity vs specificity for", name_1, "comparing neurotypical only vs other groups")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Wrapped the `d_ss_long$name` loop iterator with `unique()` and added dynamically generated `alt` text to the `ggplot2` output using `paste()` within `labs(alt = ...)`.

🎯 Why: Iterating over every row redundantly re-rendered identical charts for each duplicate occurrence of the same name, significantly impacting document generation performance. Fixing the iteration structure resolves this lag.

📸 Before/After: Before, screen readers simply announced identical or missing context for all charts in the loop, and the Quarto document executed redundant rendering logic. After, each individual scatterplot has distinct semantic context (e.g., "Scatter plot showing sensitivity vs specificity for [Outcome]"), and duplicate rendering is avoided.

♿ Accessibility: Ensures users employing screen readers or assistive tech are provided context-specific alternative text for each sub-plot generated in the loop, instead of repetitive or missing alt text.

---
*PR created automatically by Jules for task [5870946651436660865](https://jules.google.com/task/5870946651436660865) started by @jeremymiles*