### PR TITLE
🎨 Palette: Add dynamic alt text to looped diagnostic plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+
+## 2024-05-24 - Dynamic Alt Text in Plot Loops
+**Learning:** When generating multiple plots in a loop within Quarto documents, static alt text leads to ambiguous screen reader experiences as all images sound identical despite showing different data subsets.
+**Action:** Dynamically generate the alt text in labs(alt = ...) (e.g., using paste()) to reflect the specific iteration's data, ensuring each plot is uniquely identifiable.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Added dynamic `alt` text generation to the `ggplot2` scatter plots created inside a `for` loop in `adhd_adults_diagnosis.qmd`. The alt text now accurately reflects the specific diagnostic test data being plotted (e.g., 'Scatter plot of sensitivity versus specificity for Self-Report studies').

🎯 Why: In R/Quarto documents, generating plots in loops without dynamically updating metadata causes each subsequent plot image to sound identical to screen readers. This makes it impossible for visually impaired users to distinguish which plot corresponds to which data subset.

📸 Before/After: N/A (Non-visual accessibility change)

♿ Accessibility: Ensures each auto-generated scatter plot image has unique, descriptive alt text corresponding to its actual data, rather than identical empty or static metadata.

---
*PR created automatically by Jules for task [6007346108859877338](https://jules.google.com/task/6007346108859877338) started by @jeremymiles*