### PR TITLE
🎨 Palette: Replace hardcoded colors with accessible palette in forest plots

### DIFF
--- a/adhd_adult_meta_anlaysis.qmd
+++ b/adhd_adult_meta_anlaysis.qmd
@@ -144,7 +144,7 @@ plot_diagnostic_meta <-
     )
     addpoly(res$beta[1], sei = res$se[1],
             row = -1, transf = transf.ilogit, mlab = "", 
-            col = "red", cex = cex
+            col = "#D55E00", cex = cex
     )
     
     # 5. Plot Specificity
@@ -172,7 +172,7 @@ plot_diagnostic_meta <-
       sei = res$se[2], 
       row = -1, 
       transf = transf.ilogit, 
-      mlab = "", col = "red", cex = cex
+      mlab = "", col = "#D55E00", cex = cex
     )
     
     cat("<h3>Discrepant Studies</h3><br>")


### PR DESCRIPTION
* **💡 What:** Replaced the hardcoded `"red"` color in `addpoly` calls within the forest plots in `adhd_adult_meta_anlaysis.qmd` with the colorblind-friendly Okabe-Ito vermilion (`"#D55E00"`).
* **🎯 Why:** Hardcoded basic colors like "red" are difficult to distinguish for users with color vision deficiencies. This improves the visual accessibility of the core meta-analysis output.
* **📸 Before/After:** Before it used `col = "red"` for the sensitivity and specificity summary polygons, after it uses `col = "#D55E00"`.
* **♿ Accessibility:** Improved color contrast and colorblind-friendliness for data visualizations, making the meta-analysis forest plots accessible to a wider audience by adhering to established accessible palettes.

---
*PR created automatically by Jules for task [4498734973547749555](https://jules.google.com/task/4498734973547749555) started by @jeremymiles*