### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-14 - Dynamically generate alt text for visualizations in loops
+**Learning:** When using loops to render multiple data visualizations (e.g., iterating through `d_ss_long$name` to create ggplot2 charts), setting a static `alt` text in `labs(alt = ...)` causes all generated plots to share the same description. This reduces accessibility for screen reader users who cannot distinguish the specific context or data of each individual chart.
+**Action:** Always dynamically generate the `alt` text within the loop using functions like `paste()` (e.g., `alt = paste("Scatter plot for", name_1)`) to ensure each visualization accurately describes its unique data segment.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity vs specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Dynamically generates the `alt` text attribute in `ggplot2::labs()` using `paste()` when generating scatter plots within a `for` loop in `adhd_adults_diagnosis.qmd`.

🎯 Why: Previously, using a static `alt` text or missing `alt` text within loop-generated plots would cause all plots to have the same description or no description at all. This micro-UX improvement ensures each chart accurately describes the data segment being visualized.

📸 Before/After: Visual presentation remains identical. Under the hood, Quarto will generate distinct alt attributes like `alt="Scatter plot of sensitivity vs specificity for [Name]"`.

♿ Accessibility: Significantly improves the experience for users relying on screen readers by providing context-specific descriptions for each generated visualization instead of repeating identical or missing alt text.

---
*PR created automatically by Jules for task [3427346734040821739](https://jules.google.com/task/3427346734040821739) started by @jeremymiles*