### PR TITLE
🎨 Palette: Add dynamic alt text to ggplot2 charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+
+## 2024-05-14 - Add dynamic alt text to ggplot2 charts generated in loops
+**Learning:** When generating multiple data visualizations (like `ggplot2` plots) within a loop, static alt text fails to describe the specific data being presented, reducing accessibility for screen reader users.
+**Action:** Always dynamically generate the `alt` text in `labs(alt = ...)` (e.g., using `paste()`) to reflect the specific iteration's data instead of using a single static description.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot showing sensitivity and specificity for", name_1, "diagnostic tools")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Added dynamically generated `alt` text to `ggplot2` charts that are generated within a `for` loop in `adhd_adults_diagnosis.qmd`.

🎯 Why: When generating multiple charts iteratively, a static alt text fails to correctly describe the specific data being visualized in each iteration. Providing a dynamic alt text allows screen readers to accurately read out the content of each specific chart, improving accessibility.

📸 Before/After:
Before:
`labs(shape = "Neurotypical only")`

After:
`labs(shape = "Neurotypical only", alt = paste("Scatter plot showing sensitivity and specificity for", name_1, "diagnostic tools"))`

♿ Accessibility: Vastly improves screen reader comprehension by providing context-specific descriptions for every individually rendered plot in the sequence.

---
*PR created automatically by Jules for task [16415776520648821236](https://jules.google.com/task/16415776520648821236) started by @jeremymiles*