### PR TITLE
🎨 Palette: [Add dynamic alt text to ggplot charts]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2025-01-28 - Dynamic alt text in ggplot2 loops
+**Learning:** When generating multiple `ggplot2` visualizations within a loop in R or Quarto, using a static `alt` text description results in poor screen reader accessibility as all charts share the same label, making them indistinguishable.
+**Action:** Always dynamically generate the `alt` text within the `labs(alt = ...)` function (e.g., using `paste()`) based on the loop variable to ensure each generated chart has a unique and descriptive accessibility label.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "tests")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What
I've updated the `ggplot2` loop in `adhd_adults_diagnosis.qmd` to include a dynamically generated `alt` text attribute based on the `name_1` variable for the test type being plotted. Concurrently, I've corrected a bug in the loop condition itself, changing `for (name_1 in d_ss_long$name)` to `for (name_1 in unique(d_ss_long$name))` to prevent generating the exact same plot repeatedly for every row in the dataframe.

🎯 Why
By explicitly declaring the `alt` property dynamically in a loop, each output chart gets a unique, distinguishable label instead of a static generic string, providing better context. The loop fix improves document build performance and prevents visual spamming by generating charts once per test type instead of once per observation.

📸 Before/After
Before:
`labs(shape = "Neurotypical only")`
Loop generated redundant plots for every row.

After:
```R
labs(
  shape = "Neurotypical only",
  alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "tests")
)
```
Loop generates one plot per test type.

♿ Accessibility
This change improves screen reader navigation by ensuring that when navigating the rendered Quarto HTML document, each generated scatter plot announces its specific test type (e.g., "Scatter plot of sensitivity versus specificity for Biomarker tests") instead of providing redundant or absent descriptions.

---
*PR created automatically by Jules for task [14202688045153901282](https://jules.google.com/task/14202688045153901282) started by @jeremymiles*