### PR TITLE
🎨 Palette: Add dynamic alt text to looped diagnostic charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Dynamic Alt Text in Looped Visualizations
+**Learning:** Generating multiple `ggplot2` visualizations within a loop without dynamically updating the `alt` text creates duplicate, ambiguous descriptions for screen reader users, confusing the context of what each chart distinctively shows.
+**Action:** Always dynamically generate the `alt` text within the `labs(alt = ...)` function (e.g., using `paste()`) when creating plots in a loop, ensuring each output has a unique, descriptive alternative text.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, shaped by whether the control group was neurotypical only.")
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What
Added dynamic `alt` descriptions to the scatter plots generated in the `for` loop within `adhd_adults_diagnosis.qmd`, and optimized the loop iterator by wrapping it in `unique()`.

🎯 Why
When generating multiple visualizations in a loop, static alt text creates confusing, identical descriptions for each resulting output, making it impossible for screen reader users to distinguish between them. Furthermore, iterating over all rows (`d_ss_long$name`) instead of distinct values caused redundant recreation of the exact same charts, hurting efficiency.

📸 Before/After
Before: `shape = "Neurotypical only"`
After:
```R
      shape = "Neurotypical only",
      alt = paste("Scatter plot of sensitivity versus specificity for", name_1, "studies, shaped by whether the control group was neurotypical only.")
```

♿ Accessibility
Significantly improves screen reader accessibility by ensuring each dynamically generated visualization has a unique, contextually accurate description corresponding to the specific diagnostic tool being plotted.

---
*PR created automatically by Jules for task [2159156854763499657](https://jules.google.com/task/2159156854763499657) started by @jeremymiles*