### PR TITLE
🎨 Palette: Add dynamic alt text to generated plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Use accessible color palettes for data visualizations
 **Learning:** Hardcoded basic colors (like "red", "green", "yellow", "chocolate4") in data visualizations like ggplot2 can be extremely difficult to distinguish for users with color vision deficiencies, reducing accessibility.
 **Action:** Always replace basic hardcoded colors in plots with accessible, colorblind-friendly palettes such as Okabe-Ito (e.g., `#E69F00`, `#56B4E9`, `#009E73`, `#F0E442`, `#0072B2`, `#D55E00`, `#CC79A7`).
+## 2024-05-15 - Use dynamic alt text for programmatic plot generation
+**Learning:** When generating multiple `ggplot2` visualizations within a loop, static alt text causes screen readers to announce identical, unhelpful descriptions for every plot.
+**Action:** Always dynamically generate the `alt` text within the `labs(alt = ...)` function (e.g., using `paste()`) based on the loop variable to ensure each plot is uniquely identifiable and accessible.

--- a/adhd_adults_diagnosis.qmd
+++ b/adhd_adults_diagnosis.qmd
@@ -191,7 +191,7 @@ ggplot2::ggplot(
   ylim(c(0, 100))
 
 # separate charts
-for (name_1 in d_ss_long$name) {
+for (name_1 in unique(d_ss_long$name)) {
   plot <- ggplot2::ggplot(
     d_ss_long %>% dplyr::filter(name_1 == name), 
     aes(
@@ -203,7 +203,8 @@ for (name_1 in d_ss_long$name) {
     ylab("Specificity") +
     guides(colour = "none") +
     labs(
-      shape = "Neurotypical only"
+      shape = "Neurotypical only",
+      alt = paste("Scatter plot of sensitivity and specificity for", name_1)
     ) +
     ggtitle(name_1) +
     xlim(c(0, 100)) + 


### PR DESCRIPTION
💡 What: Added dynamically generated `alt` text to `ggplot2` visualizations created inside a loop and avoided redundant rendering by using `unique()`.
🎯 Why: Without dynamic alt text, screen reader users miss context about which test is being plotted, and redundant plots degrade the user experience.
📸 Before/After: Visualizations lacked alt-text and were printed repetitively; they now have explicit accessibility attributes and only one plot per diagnostic test.
♿ Accessibility: Significantly improves context for screen readers when encountering generated data visualizations.

---
*PR created automatically by Jules for task [3659586487437087979](https://jules.google.com/task/3659586487437087979) started by @jeremymiles*